### PR TITLE
feat(terraform) AWS Infrastructure Setup

### DIFF
--- a/.github/workflows/docker-ecr-build.yml
+++ b/.github/workflows/docker-ecr-build.yml
@@ -21,6 +21,7 @@ env:
   ECS_SERVICE: ${{ secrets.ECS_SERVICE }}
   ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
   CONTAINER_NAME: ${{ secrets.CONTAINER_NAME }}
+  CONTAINER_PORT: ${{ secrets.CONTAINER_PORT }}
 
 
 jobs:

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,78 @@
+resource "aws_security_group" "alb" {
+  name   = "${var.service_name}-alb"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    description = "alb-http"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "alb-port"
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "alb-egress-all"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_alb" "this" {
+  name               = "${var.service_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+
+  timeouts {}
+
+  tags = {
+    Name = "${var.service_name}-alb"
+  }
+}
+
+resource "aws_alb_target_group" "this" {
+  name        = "${var.service_name}-tg"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+  port        = 80
+
+  protocol         = "HTTP"
+  protocol_version = "HTTP1"
+
+  health_check {
+    path                = "/api/ping"
+    healthy_threshold   = 5 # default
+    matcher             = "200" # matcher
+    timeout             = 5 # default
+    unhealthy_threshold = 2 # default
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${var.service_name}-tg"
+  }
+}
+
+resource "aws_alb_listener" "this" {
+  load_balancer_arn = aws_alb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.this.arn
+  }
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -11,9 +11,9 @@ resource "aws_security_group" "alb" {
   }
 
   ingress {
-    description = "alb-port"
-    from_port   = var.container_port
-    to_port     = var.container_port
+    description = "alb-https"
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -52,7 +52,7 @@ resource "aws_alb_target_group" "this" {
   health_check {
     path                = "/api/ping"
     healthy_threshold   = 5 # default
-    matcher             = "200" # matcher
+    matcher             = "200" # default
     timeout             = 5 # default
     unhealthy_threshold = 2 # default
   }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,48 @@
+resource "aws_ecr_repository" "this" {
+  name = var.service_name
+}
+
+data "aws_iam_policy_document" "ecr" {
+  statement {
+    sid    = "AllowPushPull"
+    effect = "Allow"
+
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeRepositories",
+      "ecr:DescribeImages",
+      "ecr:ListImages",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+
+    resources = [
+      aws_ecr_repository.this.arn,
+    ]
+  }
+
+  statement {
+    sid    = "AllowGetAuthorizationToken"
+    effect = "Allow"
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ecr" {
+  name        = "${var.service_name}-ecr-policy"
+  description = "Allow push and pull images from ECR"
+
+  policy = data.aws_iam_policy_document.ecr.json
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -177,10 +177,8 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs.id]
-    subnets          = concat(
-      [for s in values(aws_subnet.privates) : s.id],
-    )
+    security_groups = [aws_security_group.ecs.id]
+    subnets         = [for s in values(aws_subnet.privates) : s.id]
   }
 
   load_balancer {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -201,15 +201,12 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    assign_public_ip = true
     security_groups  = [aws_security_group.ecs.id]
     subnets          = concat(
-      #      [for s in values(aws_subnet.privates) : s.id],
-      [for s in values(aws_subnet.publics) : s.id]
+      [for s in values(aws_subnet.privates) : s.id],
     )
   }
 
-  # FIXME: ALB 및 Private Subnet 수정 필요
   load_balancer {
     target_group_arn = aws_alb_target_group.this.arn
     container_name   = "${var.service_name}-container"

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -95,4 +95,43 @@ resource "aws_iam_role" "ecs_instance_role" {
 
 
 
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${var.service_name}-task"
+  network_mode             = "awsvpc"
+  task_role_arn            = aws_iam_role.ecs_instance_role.arn
+  execution_role_arn       = aws_iam_role.ecs_instance_role.arn
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.container_cpu
+  memory                   = var.container_memory
+
+  container_definitions = <<TASK_DEFINITION
+[
+    {
+      "name": "${var.service_name}-container",
+      "image": "${local.ACCOUNT_ID}.dkr.ecr.${var.region}.amazonaws.com/${var.service_name}:latest",
+      "portMappings": [
+        {
+          "containerPort": ${var.container_port},
+          "hostPort": ${var.container_port},
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "entryPoint": [],
+      "command": [],
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/${var.service_name}-task",
+          "awslogs-region": "${var.region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+TASK_DEFINITION
+}
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -90,30 +90,6 @@ resource "aws_security_group" "ecs" {
   vpc_id = aws_vpc.this.id
 
   ingress {
-    description = "ecs-ssh"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "ecs-http"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "ecs-https"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
     description = "ecs-port"
     from_port   = var.container_port
     to_port     = var.container_port

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "ecs_instance_role" {
+data "aws_iam_policy_document" "ecs_task_execution_role" {
   version = "2008-10-17"
   statement {
     sid     = ""
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "ecs_instance_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }
@@ -73,10 +73,9 @@ resource "aws_iam_policy" "sns_publish" {
   policy = data.aws_iam_policy_document.sns_publish.json
 }
 
-
-resource "aws_iam_role" "ecs_instance_role" {
-  name                = "${var.service_name}-ecsInstanceRole"
-  assume_role_policy  = data.aws_iam_policy_document.ecs_instance_role.json
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name                = "${var.service_name}-ecsTaskExecutionRole"
+  assume_role_policy  = data.aws_iam_policy_document.ecs_task_execution_role.json
   managed_policy_arns = [
     data.aws_iam_policy.AmazonEC2ContainerServiceforEC2Role.arn,
     data.aws_iam_policy.AmazonECSTaskExecutionRolePolicy.arn,
@@ -86,20 +85,67 @@ resource "aws_iam_role" "ecs_instance_role" {
   ]
 }
 
+resource "aws_security_group" "ecs" {
+  name   = "${var.service_name}-ecs-sg"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    description = "ecs-ssh"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "ecs-http"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "ecs-https"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "ecs-port"
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "ecs-egress-all"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
 
 
+resource "aws_ecs_cluster" "this" {
+  name = "${var.service_name}-cluster"
 
-
-
-
-
-
+  configuration {
+    execute_command_configuration {
+      logging = "DEFAULT"
+    }
+  }
+}
 
 resource "aws_ecs_task_definition" "this" {
   family                   = "${var.service_name}-task"
   network_mode             = "awsvpc"
-  task_role_arn            = aws_iam_role.ecs_instance_role.arn
-  execution_role_arn       = aws_iam_role.ecs_instance_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_execution_role.arn
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.container_cpu
   memory                   = var.container_memory
@@ -135,3 +181,44 @@ resource "aws_ecs_task_definition" "this" {
 TASK_DEFINITION
 }
 
+
+resource "aws_ecs_service" "this" {
+  name            = "${var.service_name}-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = 1
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    base              = 0
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  network_configuration {
+    assign_public_ip = true
+    security_groups  = [aws_security_group.ecs.id]
+    subnets          = concat(
+      #      [for s in values(aws_subnet.privates) : s.id],
+      [for s in values(aws_subnet.publics) : s.id]
+    )
+  }
+
+  # FIXME: ALB 및 Private Subnet 수정 필요
+  # load_balancer {
+  #   target_group_arn = aws_lb_target_group.this.arn
+  #   container_name   = "${var.service_name}-container"
+  #   container_port   = var.container_port
+  # }
+
+  timeouts {}
+
+  lifecycle {
+    ignore_changes = [
+      task_definition,
+    ]
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -188,6 +188,8 @@ resource "aws_ecs_service" "this" {
   task_definition = aws_ecs_task_definition.this.arn
   desired_count   = 1
 
+  health_check_grace_period_seconds = 10
+
   capacity_provider_strategy {
     capacity_provider = "FARGATE"
     base              = 0
@@ -208,11 +210,16 @@ resource "aws_ecs_service" "this" {
   }
 
   # FIXME: ALB 및 Private Subnet 수정 필요
-  # load_balancer {
-  #   target_group_arn = aws_lb_target_group.this.arn
-  #   container_name   = "${var.service_name}-container"
-  #   container_port   = var.container_port
-  # }
+  load_balancer {
+    target_group_arn = aws_alb_target_group.this.arn
+    container_name   = "${var.service_name}-container"
+    container_port   = var.container_port
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   timeouts {}
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -6,9 +6,17 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 1.0"
+    }
   }
 }
 
 provider "aws" {
   region = var.region
+}
+
+# https://registry.terraform.io/providers/hashicorp/template/2.2.0
+provider "template" {
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -6,17 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 1.0"
-    }
   }
 }
 
 provider "aws" {
   region = var.region
-}
-
-# https://registry.terraform.io/providers/hashicorp/template/2.2.0
-provider "template" {
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -7,6 +7,16 @@ terraform {
       version = "~> 3.0"
     }
   }
+
+  # FIXME: Cloud 도입
+  #  cloud {
+  #    hostname = "app.terraform.io"
+  #    organization = "lyfe"
+  #
+  #    workspaces {
+  #      name = "lyfe-terraform"
+  #    }
+  #  }
 }
 
 provider "aws" {

--- a/terraform/task-definition.tmpl
+++ b/terraform/task-definition.tmpl
@@ -1,5 +1,5 @@
 {
-  "family": "lyfe-task",
+  "family": "${SERVICE_NAME}-task",
   "networkMode": "awsvpc",
   "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole",
   "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole",
@@ -9,8 +9,8 @@
       "image": "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_ECR_REPOSITORY}:latest",
       "portMappings": [
         {
-          "containerPort": 3000,
-          "hostPort": 3000,
+          "containerPort": ${CONTAINER_PORT},
+          "hostPort": ${CONTAINER_PORT},
           "protocol": "tcp"
         }
       ],
@@ -23,8 +23,8 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/lyfe-task",
-          "awslogs-region": "ap-northeast-2",
+          "awslogs-group": "/ecs/${SERVICE_NAME}-task",
+          "awslogs-region": "${AWS_REGION}",
           "awslogs-stream-prefix": "ecs"
         }
       }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,3 +20,21 @@ variable "secrets_manager_name" {
   description = "Secrets Manager Name"
   type        = string
 }
+
+variable "container_port" {
+  description = "ECS Container Port"
+  type        = number
+  default     = 3000
+}
+
+variable "container_cpu" {
+  description = "ECS Container CPU"
+  type        = number
+  default     = 256
+}
+
+variable "container_memory" {
+  description = "ECS Container Memory"
+  type        = number
+  default     = 512
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,118 @@
+locals {
+  public_subnets = {
+    "${var.region}a" = "10.84.0.0/20"
+    "${var.region}c" = "10.84.16.0/20"
+  }
+  private_subnets = {
+    "${var.region}a" = "10.84.128.0/20"
+    "${var.region}c" = "10.84.144.0/20"
+  }
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.84.0.0/16"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.service_name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.service_name}-igw"
+  }
+}
+
+resource "aws_eip" "this" {
+  vpc = true
+
+  tags = {
+    Name = "${var.service_name}-eip-nat"
+  }
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.this.id
+  subnet_id     = aws_subnet.publics[
+  element(sort(keys(local.public_subnets)), 0)
+  ].id
+
+  tags = {
+    Name = "${var.service_name}-nat"
+  }
+}
+
+resource "aws_subnet" "privates" {
+  for_each = local.private_subnets
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = each.value
+
+  availability_zone = each.key
+
+  tags = {
+    Name = "${var.service_name}-privates-${each.key}"
+  }
+}
+
+resource "aws_subnet" "publics" {
+  for_each = local.public_subnets
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = each.value
+
+  map_public_ip_on_launch = true # Public IP 부여 여부
+  availability_zone       = each.key
+
+  tags = {
+    Name = "${var.service_name}-publics-${each.key}"
+  }
+}
+
+resource "aws_default_route_table" "public" {
+  default_route_table_id = aws_vpc.this.default_route_table_id
+
+  tags = {
+    Name = "${var.service_name}-public"
+  }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_default_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0" # All Access to Internet
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.service_name}-private"
+  }
+}
+
+resource "aws_route" "privates_nat_gateway" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0" # All Access to Nat Gateway
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+# docs: https://docs.aws.amazon.com/ko_kr/vpc/latest/userguide/WorkWithRouteTables.html
+resource "aws_route_table_association" "publics" {
+  for_each = local.public_subnets
+
+  subnet_id      = aws_subnet.publics[each.key].id
+  route_table_id = aws_default_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = local.private_subnets
+
+  subnet_id      = aws_subnet.privates[each.key].id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
## Overview
1. VPC 및 Subnet 설정
   - VPC와 Subnet을 새로 구성하였습니다.
   - Private 및 Public 용도로 각각 2개의 Subnet을 생성하였습니다.
   - Private Subnet이 Internet Gateway에 접근할 수 있도록 NAT Gateway를 연동하였습니다.
2. ECR 설정
   - Docker Hub 대신 ECR을 사용하여 Docker Image를 관리하도록 하였습니다.
3. ECS 구현
   - ECS Cluster 및 Service를 설정해, 컨테이너화된 어플리케이션을 서비스하였습니다.
   - ECS Service 구성요소는 Terraform 내의 `aws_ecs_task_definition` 설정을 통해 관리됩니다.
4. ALB 구현
   - ALB를 통해 ECS의 모든 Task를 단일 엔드포인트에서 접근하게 하였습니다.
   - ALB Target Group 에서 Task의 상태를 주기적으로 Health Check하여 관리합니다.

## Next
1. `task-definition.tmpl` 파일을 Terraform 구성요소로 통합합니다.
2. CI/CD 파이프라인을 Github Action + Terraform으로 재구성합니다.
3. 각 기능을 모듈별로 분리하여, 하나의 파일에 여러 리소스가 포함되지 않도록 수정합니다.
4. Terraform Cloud를 도입해 `.tfstate` 파일을 클라우드 환경에서 관리하도록 변경합니다.