### PR TITLE
feat(auth) Access, Refresh Token Setup by passport

### DIFF
--- a/.github/workflows/docker-ecr-build.yml
+++ b/.github/workflows/docker-ecr-build.yml
@@ -43,6 +43,8 @@ jobs:
         env:
           AWS_SNS_REGION: ${{secrets.AWS_SNS_REGION}}
           DATABASE_URL: ${{secrets.DATABASE_URL}}
+          JWT_SECRET_KEY: ${{secrets.JWT_SECRET_KEY}}
+          JWT_EXPIRATION_TIME: ${{secrets.JWT_EXPIRATION_TIME}}
           JWT_REFRESH_SECRET_KEY: ${{secrets.JWT_REFRESH_SECRET_KEY}}
           JWT_REFRESH_EXPIRATION_TIME: ${{secrets.JWT_REFRESH_EXPIRATION_TIME}}
         run: |

--- a/src/adapter/in/web/admin/admin.controller.ts
+++ b/src/adapter/in/web/admin/admin.controller.ts
@@ -32,7 +32,9 @@ import {
   TokenUsecase,
 } from '@application/port/in/auth/token/token.usecase';
 import { Admin } from '@domain/admin/admin';
+import { RefreshTokenHeader } from '@common/decorator/refresh-token-header.decorator';
 import { JwtAdminRefreshGuard } from '@common/guard/jwt-admin-refresh.guard';
+import { AccessTokenHeader } from '@common/decorator/access-token-header.decorator';
 
 // TODO: Admin 도메인은 추후 별도의 서버리스 서비스로 분리될 예정.
 @Controller('admin')
@@ -91,6 +93,7 @@ export class AdminController {
       },
     },
   })
+  @AccessTokenHeader()
   @ApiResponse({
     status: 201,
     description: 'Return success',
@@ -109,6 +112,7 @@ export class AdminController {
 
   @Post('/refresh')
   @ApiOperation({ summary: 'Refresh Token' })
+  @RefreshTokenHeader()
   @ApiResponse({
     status: 200,
     description: 'Return success',

--- a/src/adapter/in/web/admin/admin.controller.ts
+++ b/src/adapter/in/web/admin/admin.controller.ts
@@ -35,6 +35,7 @@ import { Admin } from '@domain/admin/admin';
 import { RefreshTokenHeader } from '@common/decorator/refresh-token-header.decorator';
 import { JwtAdminRefreshGuard } from '@common/guard/jwt-admin-refresh.guard';
 import { AccessTokenHeader } from '@common/decorator/access-token-header.decorator';
+import { JwtAdminGuard } from '@common/guard/jwt-admin.guard';
 
 // TODO: Admin 도메인은 추후 별도의 서버리스 서비스로 분리될 예정.
 @Controller('admin')
@@ -99,11 +100,13 @@ export class AdminController {
     description: 'Return success',
     type: String,
   })
+  @UseGuards(JwtAdminGuard)
   async adminIssueInvitation(
+    @Request() req: any,
     @Body('inviteePhoneNumber') inviteePhoneNumber?: string,
   ) {
     await this.adminIssueInvitationUsecase.exec({
-      adminId: '64c37df1e55842f8ec39a486',
+      adminId: req.user.id,
       inviteePhoneNumber,
     });
 
@@ -121,7 +124,7 @@ export class AdminController {
   @UseGuards(JwtAdminRefreshGuard)
   async refresh(@Request() req: any) {
     const accessToken = await this.adminTokenUsecase.getJwtAccessToken({
-      id: req.user.adminId,
+      id: req.user.id,
     });
 
     req.res.setHeader('Set-Cookie', [

--- a/src/adapter/in/web/admin/admin.controller.ts
+++ b/src/adapter/in/web/admin/admin.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Inject, Post, Request } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Inject,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiExtraModels,
@@ -25,6 +32,7 @@ import {
   TokenUsecase,
 } from '@application/port/in/auth/token/token.usecase';
 import { Admin } from '@domain/admin/admin';
+import { JwtAdminRefreshGuard } from '@common/guard/jwt-admin-refresh.guard';
 
 // TODO: Admin 도메인은 추후 별도의 서버리스 서비스로 분리될 예정.
 @Controller('admin')
@@ -95,6 +103,26 @@ export class AdminController {
       adminId: '64c37df1e55842f8ec39a486',
       inviteePhoneNumber,
     });
+
+    return 'success';
+  }
+
+  @Post('/refresh')
+  @ApiOperation({ summary: 'Refresh Token' })
+  @ApiResponse({
+    status: 200,
+    description: 'Return success',
+    type: String,
+  })
+  @UseGuards(JwtAdminRefreshGuard)
+  async refresh(@Request() req: any) {
+    const accessToken = await this.adminTokenUsecase.getJwtAccessToken({
+      id: req.user.adminId,
+    });
+
+    req.res.setHeader('Set-Cookie', [
+      await this.adminTokenUsecase.parseCookieByJwtAccessToken(accessToken),
+    ]);
 
     return 'success';
   }

--- a/src/adapter/in/web/admin/admin.presenter.ts
+++ b/src/adapter/in/web/admin/admin.presenter.ts
@@ -34,13 +34,13 @@ export class AdminPresenter {
     description: '인증 토큰',
   })
   @IsString()
-  token: string;
+  RefreshToken: string;
 
   constructor(admin: Admin) {
     this.id = admin.id;
     this.email = admin.email;
     this.createdAt = admin.createdAt;
     this.updatedAt = admin.updatedAt;
-    this.token = admin.getAuthToken().token;
+    this.RefreshToken = admin.getAuthToken().token;
   }
 }

--- a/src/adapter/in/web/auth/auth.controller.ts
+++ b/src/adapter/in/web/auth/auth.controller.ts
@@ -46,6 +46,7 @@ import {
   TokenUsecase,
 } from '@application/port/in/auth/token/token.usecase';
 import { User } from '@domain/user/user';
+import { JwtAuthRefreshGuard } from '@common/guard/jwt-auth-refresh.guard';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -161,5 +162,30 @@ export class AuthController {
     return {
       invitationCode: invitation.invitationCode,
     };
+  }
+
+  @Post('/refresh')
+  @ApiOperation({ summary: 'Refresh Token' })
+  @ApiResponse({
+    status: 200,
+    description: 'Return success',
+    type: String,
+    headers: {
+      'Set-Cookie': {
+        description: "The 'AccessToken'",
+      },
+    },
+  })
+  @UseGuards(JwtAuthRefreshGuard)
+  async refresh(@Request() req: any) {
+    const accessToken = await this.tokenUsecase.getJwtAccessToken({
+      id: req.user.userId,
+    });
+
+    req.res.setHeader('Set-Cookie', [
+      await this.tokenUsecase.parseCookieByJwtAccessToken(accessToken),
+    ]);
+
+    return 'success';
   }
 }

--- a/src/adapter/in/web/auth/auth.controller.ts
+++ b/src/adapter/in/web/auth/auth.controller.ts
@@ -47,6 +47,8 @@ import {
 } from '@application/port/in/auth/token/token.usecase';
 import { User } from '@domain/user/user';
 import { JwtAuthRefreshGuard } from '@common/guard/jwt-auth-refresh.guard';
+import { AccessTokenHeader } from '@common/decorator/access-token-header.decorator';
+import { RefreshTokenHeader } from '@common/decorator/refresh-token-header.decorator';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -86,6 +88,11 @@ export class AuthController {
     status: 200,
     description: 'Return success',
     type: [UserPresenter],
+    headers: {
+      'Set-Cookie': {
+        description: "The 'AccessToken' and 'RefreshToken'",
+      },
+    },
   })
   async verifyAuthCode(
     @Body() verifyAuthCodeDto: VerifyAuthCodeDto,
@@ -114,6 +121,11 @@ export class AuthController {
     status: 200,
     description: 'Return user',
     type: UserPresenter,
+    headers: {
+      'Set-Cookie': {
+        description: "The 'AccessToken' and 'RefreshToken'",
+      },
+    },
   })
   async signUp(
     @Body() signUpUserDto: SignUpUserDto,
@@ -135,9 +147,11 @@ export class AuthController {
   }
 
   @Post('sign-out')
+  @ApiOperation({ summary: 'Sign Out User' })
+  @AccessTokenHeader()
   @UseGuards(JwtAuthGuard)
   async signOut() {
-    console.log('Hello world');
+    return 'success';
   }
 
   @Get('invitation/:phoneNumber')
@@ -166,6 +180,7 @@ export class AuthController {
 
   @Post('/refresh')
   @ApiOperation({ summary: 'Refresh Token' })
+  @RefreshTokenHeader()
   @ApiResponse({
     status: 200,
     description: 'Return success',

--- a/src/adapter/in/web/auth/auth.controller.ts
+++ b/src/adapter/in/web/auth/auth.controller.ts
@@ -194,7 +194,7 @@ export class AuthController {
   @UseGuards(JwtAuthRefreshGuard)
   async refresh(@Request() req: any) {
     const accessToken = await this.tokenUsecase.getJwtAccessToken({
-      id: req.user.userId,
+      id: req.user.id,
     });
 
     req.res.setHeader('Set-Cookie', [

--- a/src/adapter/in/web/service-proxy/auth.service-proxy.module.ts
+++ b/src/adapter/in/web/service-proxy/auth.service-proxy.module.ts
@@ -10,7 +10,6 @@ import { VERIFICATION_AUTH_CODE_USECASE } from '@application/port/in/auth/verifi
 import { VerificationAuthCodeService } from '@application/service/auth/verification-auth-code.service';
 import { SIGN_UP_USECASE } from '@application/port/in/auth/sign-up.usecase';
 import { UserMongoRepository } from '@adapter/out/persistence/user/user.mongo.repository';
-import { AuthRepository } from '@application/port/out/auth/auth.repository';
 import { SignUpService } from '@application/service/auth/sign-up.service';
 import { BcryptAdapter } from '@adapter/security/bcrypt/bcrypt.adapter';
 import { BcryptModule } from '@adapter/security/bcrypt/bcrypt.module';
@@ -24,9 +23,7 @@ import { SIGN_IN_USECASE } from '@application/port/in/auth/sign-in.usecase';
 import { SignInService } from '@application/service/auth/sign-in.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { LoggerModule } from '@adapter/common/logger/logger.module';
-import { AdminMongoRepository } from '@adapter/out/persistence/admin/admin.mongo.repository';
 import { InvitationMongoRepository } from '@adapter/out/persistence/auth/invitation/invitation.mongo.repository';
-import { Admin } from '@domain/admin/admin';
 import { User } from '@domain/user/user';
 
 @Module({

--- a/src/adapter/in/web/user/user.presenter.ts
+++ b/src/adapter/in/web/user/user.presenter.ts
@@ -37,10 +37,10 @@ export class UserPresenter {
   @ApiProperty({
     example:
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2NGE4MDIwNzI3ZmNiMWU5ZDc1YjRjMjUiLCJpYXQiOjE2ODg3MzI4NDAsImV4cCI6MTcyMDI2ODg0MH0.ESQ_fK3NP1uCOugFPQL-qeOJWcFWf9tNk6DECHYHhdY',
-    description: '유저의 토큰',
+    description: '유저의 리프레시 토큰',
   })
   @IsString()
-  token: string;
+  RefreshToken: string;
 
   @ApiProperty({
     example: new Date('2023-06-29T02:12:37.810Z'),
@@ -53,6 +53,6 @@ export class UserPresenter {
     this.userInfo = user.getUserInfo();
     this.phoneNumber = user.phoneNumber;
     this.createdAt = user.createdAt;
-    this.token = user.getAuthToken().token;
+    this.RefreshToken = user.getAuthToken().token;
   }
 }

--- a/src/adapter/out/persistence/admin/mapper/admin.mapper.ts
+++ b/src/adapter/out/persistence/admin/mapper/admin.mapper.ts
@@ -6,7 +6,7 @@ export class AdminMapper {
     if (!adminEntity) return null;
 
     const admin = new Admin(
-      adminEntity.id,
+      adminEntity._id,
       adminEntity.email,
       adminEntity.password,
       adminEntity.createdAt,

--- a/src/adapter/out/persistence/admin/schema/admin.schema.ts
+++ b/src/adapter/out/persistence/admin/schema/admin.schema.ts
@@ -3,7 +3,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { AuthToken } from '@domain/user/auth-token';
 
 export class AdminEntity extends Document {
-  id?: string;
+  _id?: string;
 
   email: string;
 
@@ -16,7 +16,7 @@ export class AdminEntity extends Document {
   authToken?: AuthToken;
 
   constructor(
-    id: string,
+    _id: string,
     email: string,
     password: string,
     createdAt: Date,
@@ -25,7 +25,7 @@ export class AdminEntity extends Document {
   ) {
     super();
 
-    this.id = id;
+    this._id = _id;
     this.email = email;
     this.password = password;
     this.createdAt = createdAt;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,9 @@ import { JwtModule } from '@adapter/security/jwt/jwt.module';
 import { JwtStrategy } from '@common/strategy/jwt.strategy';
 import { PassportModule } from '@nestjs/passport';
 import { LoggerModule } from '@adapter/common/logger/logger.module';
+import { JwtAdminStrategy } from '@common/strategy/jwt-admin.strategy';
+import { JwtRefreshStrategy } from '@common/strategy/jwt-refresh.strategy';
+import { JwtAdminRefreshStrategy } from '@common/strategy/jwt-admin-refresh.strategy';
 
 @Module({
   imports: [
@@ -22,6 +25,11 @@ import { LoggerModule } from '@adapter/common/logger/logger.module';
     AdapterModule,
   ],
   controllers: [AppController],
-  providers: [JwtStrategy],
+  providers: [
+    JwtStrategy,
+    JwtRefreshStrategy,
+    JwtAdminStrategy,
+    JwtAdminRefreshStrategy,
+  ],
 })
 export class AppModule {}

--- a/src/application/port/in/auth/command/auth.command.ts
+++ b/src/application/port/in/auth/command/auth.command.ts
@@ -1,4 +1,5 @@
 import { Geometry } from '@domain/user/geometry';
+import { AuthToken } from '@domain/user/auth-token';
 
 export class SignUpCommand {
   nickname: string;
@@ -25,6 +26,7 @@ export class SignUpCommand {
     this.locationUpdatedAt = locationUpdatedAt;
   }
 }
+
 export class SignUpDetails {
   constructor(
     readonly nickname: string,
@@ -45,6 +47,7 @@ export class SignInCommand {
 export class AuthVerificationResponseCommand<T> {
   constructor(
     readonly accountable: T,
-    readonly cookieWithRefreshToken: string, // readonly cookieWithAccessToken: string,
+    readonly accessToken: AuthToken,
+    readonly refreshToken: AuthToken,
   ) {}
 }

--- a/src/application/port/in/auth/token/token.usecase.ts
+++ b/src/application/port/in/auth/token/token.usecase.ts
@@ -2,6 +2,12 @@ import { AuthToken } from '@domain/user/auth-token';
 import { JwtServicePayload } from '@application/port/security/jwt/jwt.port';
 
 export interface TokenUsecase<T> {
+  getAccountable(payload: JwtServicePayload): Promise<T>;
+
+  getJwtAccessToken(payload: JwtServicePayload): Promise<AuthToken>;
+
+  parseCookieByJwtAccessToken(authToken: AuthToken): Promise<string>;
+
   getJwtRefreshToken(payload: JwtServicePayload): Promise<AuthToken>;
 
   parseCookieByJwtRefreshToken(authToken: AuthToken): Promise<string>;

--- a/src/application/port/in/auth/token/token.usecase.ts
+++ b/src/application/port/in/auth/token/token.usecase.ts
@@ -1,7 +1,5 @@
-import { User } from '@domain/user/user';
 import { AuthToken } from '@domain/user/auth-token';
 import { JwtServicePayload } from '@application/port/security/jwt/jwt.port';
-import { Admin } from '@domain/admin/admin';
 
 export interface TokenUsecase<T> {
   getJwtRefreshToken(payload: JwtServicePayload): Promise<AuthToken>;

--- a/src/application/service/admin/sign-in-admin.service.ts
+++ b/src/application/service/admin/sign-in-admin.service.ts
@@ -6,6 +6,7 @@ import { SignInAdminCommand } from '@application/port/in/admin/command/sign-in-a
 import { AuthenticationFailedException } from '@application/service/admin/exception/authentication-failed.exception';
 import { TokenUsecase } from '@application/port/in/auth/token/token.usecase';
 import { AuthVerificationResponseCommand } from '@application/port/in/auth/command/auth.command';
+import { AuthToken } from '@domain/user/auth-token';
 
 export class SignInAdminService implements SignInAdminUsecase {
   constructor(
@@ -17,26 +18,48 @@ export class SignInAdminService implements SignInAdminUsecase {
   async exec(
     signInAdminCommand: SignInAdminCommand,
   ): Promise<AuthVerificationResponseCommand<Admin>> {
-    const { email, password } = signInAdminCommand;
+    const admin = await this.verifyAdmin(signInAdminCommand);
 
-    const admin = await this.adminRepository.getAdminByEmail(email);
-    if (!admin || !(await this.bcryptPort.compare(password, admin.password)))
-      throw new AuthenticationFailedException(
-        '어드민 로그인에 실패하였습니다.',
-      );
+    const accessToken = await this.generateAccessToken(admin.id);
+    const refreshToken = await this.generateRefreshToken(admin.id);
 
-    const authToken = await this.tokenUsecase.getJwtRefreshToken({
-      id: admin.id,
-    });
-
-    const cookieWithRefreshToken =
-      await this.tokenUsecase.parseCookieByJwtRefreshToken(authToken);
-
-    admin.setAuthToken(authToken);
+    admin.setAuthToken(refreshToken);
 
     return new AuthVerificationResponseCommand<Admin>(
       admin,
-      cookieWithRefreshToken,
+      accessToken,
+      refreshToken,
     );
+  }
+
+  private async verifyAdmin(
+    signInAdminCommand: SignInAdminCommand,
+  ): Promise<Admin> {
+    const { email, password } = signInAdminCommand;
+
+    const admin = await this.adminRepository.getAdminByEmail(email);
+
+    if (!admin || !(await this.isValidPassword(password, admin.password))) {
+      throw new AuthenticationFailedException(
+        '어드민 로그인에 실패하였습니다.',
+      );
+    }
+
+    return admin;
+  }
+
+  private async isValidPassword(
+    password: string,
+    encryptedPassword: string,
+  ): Promise<boolean> {
+    return await this.bcryptPort.compare(password, encryptedPassword);
+  }
+
+  private async generateAccessToken(adminId: string): Promise<AuthToken> {
+    return await this.tokenUsecase.getJwtAccessToken({ id: adminId });
+  }
+
+  private async generateRefreshToken(adminId: string): Promise<AuthToken> {
+    return await this.tokenUsecase.getJwtRefreshToken({ id: adminId });
   }
 }

--- a/src/application/service/auth/token/token.service.ts
+++ b/src/application/service/auth/token/token.service.ts
@@ -20,7 +20,7 @@ export class TokenService<T extends Accountable> implements TokenUsecase<T> {
   async getJwtRefreshToken(payload: JwtServicePayload): Promise<AuthToken> {
     const secret = this.jwtConfig.getJwtRefreshSecretKey();
     const expiresIn = this.jwtConfig.getJwtRefreshExpirationTime() + 's';
-    const token = new AuthToken(
+    const token = AuthToken.newInstance(
       this.jwtPort.createToken(payload, secret, expiresIn),
     );
 
@@ -59,7 +59,7 @@ export class TokenService<T extends Accountable> implements TokenUsecase<T> {
 
     await this.tokenRepository.updateRefreshToken(
       payload.id,
-      new AuthToken(hashedRefreshToken),
+      AuthToken.newInstance(hashedRefreshToken),
     );
   }
 }

--- a/src/common/config/environment-config.service.ts
+++ b/src/common/config/environment-config.service.ts
@@ -19,12 +19,20 @@ export class EnvironmentConfigService
     return this.configService.get<string>('DATABASE_URL');
   }
 
-  getJwtRefreshExpirationTime(): number {
-    return this.configService.get<number>('JWT_REFRESH_EXPIRATION_TIME');
+  getJwtSecret(): string {
+    return this.configService.get<string>('JWT_SECRET_KEY');
+  }
+
+  getJwtExpirationTime(): number {
+    return this.configService.get<number>('JWT_EXPIRATION_TIME');
   }
 
   getJwtRefreshSecretKey(): string {
     return this.configService.get<string>('JWT_REFRESH_SECRET_KEY');
+  }
+
+  getJwtRefreshExpirationTime(): number {
+    return this.configService.get<number>('JWT_REFRESH_EXPIRATION_TIME');
   }
 
   getAwsSnsRegion(): string {

--- a/src/common/decorator/access-token-header.decorator.ts
+++ b/src/common/decorator/access-token-header.decorator.ts
@@ -1,0 +1,8 @@
+import { ApiHeader } from '@nestjs/swagger';
+
+export function AccessTokenHeader() {
+  return ApiHeader({
+    name: 'Cookie',
+    description: 'AccessToken=YOUR_JWT_TOKEN',
+  });
+}

--- a/src/common/decorator/refresh-token-header.decorator.ts
+++ b/src/common/decorator/refresh-token-header.decorator.ts
@@ -1,0 +1,8 @@
+import { ApiHeader } from '@nestjs/swagger';
+
+export function RefreshTokenHeader() {
+  return ApiHeader({
+    name: 'Cookie',
+    description: 'RefreshToken=YOUR_JWT_TOKEN',
+  });
+}

--- a/src/common/exception/unauthorized.exception.ts
+++ b/src/common/exception/unauthorized.exception.ts
@@ -1,0 +1,7 @@
+import { BaseException } from '@common/exception/base.exception';
+
+export class UnauthorizedException extends BaseException {
+  constructor(message = 'Unauthorized Exception', status = 401) {
+    super(message, status);
+  }
+}

--- a/src/common/guard/jwt-admin-refresh.guard.ts
+++ b/src/common/guard/jwt-admin-refresh.guard.ts
@@ -1,0 +1,5 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtAdminRefreshGuard extends AuthGuard('jwt-admin-refresh') {}

--- a/src/common/guard/jwt-admin.guard.ts
+++ b/src/common/guard/jwt-admin.guard.ts
@@ -1,0 +1,5 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtAdminGuard extends AuthGuard('jwt-admin') {}

--- a/src/common/guard/jwt-auth-refresh.guard.ts
+++ b/src/common/guard/jwt-auth-refresh.guard.ts
@@ -1,0 +1,5 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtAuthRefreshGuard extends AuthGuard('jwt-refresh') {}

--- a/src/common/strategy/jwt-admin-refresh.strategy.ts
+++ b/src/common/strategy/jwt-admin-refresh.strategy.ts
@@ -9,9 +9,9 @@ import {
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
-import { NotFoundException } from '@common/exception/not-found.exception';
 import { AuthToken } from '@domain/user/auth-token';
 import { Admin } from '@domain/admin/admin';
+import { UnauthorizedException } from '@common/exception/unauthorized.exception';
 
 @Injectable()
 export class JwtAdminRefreshStrategy extends PassportStrategy(
@@ -45,7 +45,7 @@ export class JwtAdminRefreshStrategy extends PassportStrategy(
 
     if (!admin) {
       this.logger.warn('JwtStrategy', 'Admin not found or hash not correct.');
-      throw new NotFoundException(
+      throw new UnauthorizedException(
         '관리자를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }

--- a/src/common/strategy/jwt-admin-refresh.strategy.ts
+++ b/src/common/strategy/jwt-admin-refresh.strategy.ts
@@ -4,43 +4,52 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { JwtServicePayload } from '@application/port/security/jwt/jwt.port';
 import {
-  TOKEN_USECASE,
+  ADMIN_TOKEN_USECASE,
   TokenUsecase,
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { NotFoundException } from '@common/exception/not-found.exception';
-import { User } from '@domain/user/user';
+import { AuthToken } from '@domain/user/auth-token';
+import { Admin } from '@domain/admin/admin';
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
+export class JwtAdminRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-admin-refresh',
+) {
   constructor(
-    @Inject(TOKEN_USECASE)
-    private readonly tokenUsecase: TokenUsecase<User>,
+    @Inject(ADMIN_TOKEN_USECASE)
+    private readonly tokenUsecase: TokenUsecase<Admin>,
     private readonly configService: EnvironmentConfigService,
     private readonly logger: LoggerAdapter,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
-          return request?.cookies?.AccessToken;
+          return request?.cookies?.RefreshToken;
         },
       ]),
-      secretOrKey: configService.getJwtSecret(),
+      secretOrKey: configService.getJwtRefreshSecretKey(),
       passReqToCallback: true,
     });
   }
 
+  // FIXME: Admin Environment Key 추가하기
   async validate(request: Request, payload: JwtServicePayload) {
-    const user = await this.tokenUsecase.getAccountable(payload);
+    const refreshToken = request.cookies?.RefreshToken;
+    const admin = await this.tokenUsecase.getAccountableIfRefreshTokenMatches(
+      AuthToken.newInstance(refreshToken),
+      payload,
+    );
 
-    if (!user) {
-      this.logger.warn('JwtStrategy', 'User not found or hash not correct.');
+    if (!admin) {
+      this.logger.warn('JwtStrategy', 'Admin not found or hash not correct.');
       throw new NotFoundException(
-        '유저를 찾을 수 없거나, 인증에 실패하였습니다.',
+        '관리자를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }
 
-    return user;
+    return admin;
   }
 }

--- a/src/common/strategy/jwt-admin.strategy.ts
+++ b/src/common/strategy/jwt-admin.strategy.ts
@@ -9,8 +9,8 @@ import {
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
-import { NotFoundException } from '@common/exception/not-found.exception';
 import { Admin } from '@domain/admin/admin';
+import { UnauthorizedException } from '@common/exception/unauthorized.exception';
 
 @Injectable()
 export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
@@ -37,7 +37,7 @@ export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
 
     if (!admin) {
       this.logger.warn('JwtStrategy', 'Admin not found or hash not correct.');
-      throw new NotFoundException(
+      throw new UnauthorizedException(
         '관리자를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }

--- a/src/common/strategy/jwt-admin.strategy.ts
+++ b/src/common/strategy/jwt-admin.strategy.ts
@@ -4,19 +4,19 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { JwtServicePayload } from '@application/port/security/jwt/jwt.port';
 import {
-  TOKEN_USECASE,
+  ADMIN_TOKEN_USECASE,
   TokenUsecase,
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { NotFoundException } from '@common/exception/not-found.exception';
-import { User } from '@domain/user/user';
+import { Admin } from '@domain/admin/admin';
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
+export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
   constructor(
-    @Inject(TOKEN_USECASE)
-    private readonly tokenUsecase: TokenUsecase<User>,
+    @Inject(ADMIN_TOKEN_USECASE)
+    private readonly tokenUsecase: TokenUsecase<Admin>,
     private readonly configService: EnvironmentConfigService,
     private readonly logger: LoggerAdapter,
   ) {
@@ -31,16 +31,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
+  // FIXME: Admin Environment Key 추가하기
   async validate(request: Request, payload: JwtServicePayload) {
-    const user = await this.tokenUsecase.getAccountable(payload);
+    const admin = await this.tokenUsecase.getAccountable(payload);
 
-    if (!user) {
-      this.logger.warn('JwtStrategy', 'User not found or hash not correct.');
+    if (!admin) {
+      this.logger.warn('JwtStrategy', 'Admin not found or hash not correct.');
       throw new NotFoundException(
-        '유저를 찾을 수 없거나, 인증에 실패하였습니다.',
+        '관리자를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }
-
-    return user;
+    return admin;
   }
 }

--- a/src/common/strategy/jwt-refresh.strategy.ts
+++ b/src/common/strategy/jwt-refresh.strategy.ts
@@ -10,10 +10,14 @@ import {
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { NotFoundException } from '@common/exception/not-found.exception';
+import { AuthToken } from '@domain/user/auth-token';
 import { User } from '@domain/user/user';
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
   constructor(
     @Inject(TOKEN_USECASE)
     private readonly tokenUsecase: TokenUsecase<User>,
@@ -23,16 +27,20 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
-          return request?.cookies?.AccessToken;
+          return request?.cookies?.RefreshToken;
         },
       ]),
-      secretOrKey: configService.getJwtSecret(),
+      secretOrKey: configService.getJwtRefreshSecretKey(),
       passReqToCallback: true,
     });
   }
 
   async validate(request: Request, payload: JwtServicePayload) {
-    const user = await this.tokenUsecase.getAccountable(payload);
+    const authToken = request.cookies?.RefreshToken;
+    const user = await this.tokenUsecase.getAccountableIfRefreshTokenMatches(
+      AuthToken.newInstance(authToken),
+      payload,
+    );
 
     if (!user) {
       this.logger.warn('JwtStrategy', 'User not found or hash not correct.');

--- a/src/common/strategy/jwt-refresh.strategy.ts
+++ b/src/common/strategy/jwt-refresh.strategy.ts
@@ -9,9 +9,9 @@ import {
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
-import { NotFoundException } from '@common/exception/not-found.exception';
 import { AuthToken } from '@domain/user/auth-token';
 import { User } from '@domain/user/user';
+import { UnauthorizedException } from '@common/exception/unauthorized.exception';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(
@@ -44,7 +44,7 @@ export class JwtRefreshStrategy extends PassportStrategy(
 
     if (!user) {
       this.logger.warn('JwtStrategy', 'User not found or hash not correct.');
-      throw new NotFoundException(
+      throw new UnauthorizedException(
         '유저를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }

--- a/src/common/strategy/jwt.strategy.ts
+++ b/src/common/strategy/jwt.strategy.ts
@@ -9,8 +9,8 @@ import {
 } from '@application/port/in/auth/token/token.usecase';
 import { EnvironmentConfigService } from '@common/config/environment-config.service';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
-import { NotFoundException } from '@common/exception/not-found.exception';
 import { User } from '@domain/user/user';
+import { UnauthorizedException } from '@common/exception/unauthorized.exception';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -36,7 +36,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
     if (!user) {
       this.logger.warn('JwtStrategy', 'User not found or hash not correct.');
-      throw new NotFoundException(
+      throw new UnauthorizedException(
         '유저를 찾을 수 없거나, 인증에 실패하였습니다.',
       );
     }

--- a/src/common/strategy/jwt.strategy.ts
+++ b/src/common/strategy/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
@@ -35,7 +35,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(request: Request, payload: JwtServicePayload) {
     const authToken = request.cookies?.Refresh;
     const user = await this.tokenUsecase.getAccountableIfRefreshTokenMatches(
-      new AuthToken(authToken),
+      AuthToken.newInstance(authToken),
       payload,
     );
 

--- a/src/domain/config/jwt.config.ts
+++ b/src/domain/config/jwt.config.ts
@@ -1,4 +1,8 @@
 export interface JwtConfig {
+  getJwtSecret(): string;
+
+  getJwtExpirationTime(): number;
+
   getJwtRefreshSecretKey(): string;
 
   getJwtRefreshExpirationTime(): number;

--- a/src/domain/user/auth-token.ts
+++ b/src/domain/user/auth-token.ts
@@ -1,6 +1,7 @@
 export class AuthToken {
-  constructor(
-    public readonly token: string,
-    public readonly createdAt: Date = new Date(),
-  ) {}
+  constructor(public readonly token: string, public readonly createdAt: Date) {}
+
+  static newInstance(token: string, createdAt: Date = new Date()) {
+    return new AuthToken(token, createdAt);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ function initApplication(app: INestApplication): void {
     methods: ['*'],
     preflightContinue: false,
     optionsSuccessStatus: 204,
+    credentials: true,
   });
 
   // Base routing
@@ -52,6 +53,24 @@ function initSwagger(app: INestApplication): void {
   const config = new DocumentBuilder()
     .setTitle(`LYFE Test [${process.env.NODE_ENV}]`)
     .setVersion(process.env.packageVersion)
+    .addCookieAuth(
+      'AccessToken',
+      {
+        type: 'apiKey',
+        in: 'cookie',
+        scheme: 'basic',
+      },
+      'AccessToken',
+    )
+    .addCookieAuth(
+      'RefreshToken',
+      {
+        type: 'apiKey',
+        in: 'cookie',
+        scheme: 'basic',
+      },
+      'RefreshToken',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
## Overview
1. Access Token 및 Refresh Token 구현
   - Access Token, Refresh Token을 도입하여 보안성을 향상시켰습니다.
   - 그에 맞게 Passport의 Custom Strategy를 도입하였습니다.
2. Cookie 발급 리팩토링
   - Cookie 발급의 책임을 Service에서 Controller로 수정하였습니다.
   - Token Service는 이제 `Accountable`한 도메인의 Access 및 Refresh Token을 발급하는 책임만 담당합니다.
3. Access Token 발급 API 생성
   - 사용자 및 어드민의 Access Token 발급을 위한 `/refresh` API를 추가하였습니다.
   - 프론트엔드에서 `Unauthorized Exception`을 전달받을 때, 해당 API를 호출하도록 구성합니다.
4. Swagger 상세화
   - Request 및 Response에서 헤더 및 쿠키 정보를 더욱 상세하게 표시하였습니다.
   - Custom Decorator를 도입하여 중복된 데코레이터를 관리하였습니다.

## Next
1. Domain 생성 시, 정적 팩토리 메서드 패턴을 사용하도록 리팩토링합니다.
   - 생성에 대한 책임을 정적 팩토리 메서드에 위임하도록 코드를 수정합니다.
2. Custom Strategy를 Module로 통합합니다.
3. Swagger에서 사용하는 중복된 데코레이터를 통합합니다.