### PR TITLE
refactor: Enhanced Domain and Repository Design

### DIFF
--- a/src/adapter/out/persistence/admin/mapper/admin.mapper.ts
+++ b/src/adapter/out/persistence/admin/mapper/admin.mapper.ts
@@ -1,8 +1,17 @@
 import { Admin } from '@domain/admin/admin';
 import { AdminEntity } from '@adapter/out/persistence/admin/schema/admin.schema';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 
-export class AdminMapper {
-  public static toDomain(adminEntity: AdminEntity): Admin {
+@Injectable()
+export class AdminMapper implements MapperPort<AdminEntity, Admin> {
+  constructor(
+    @InjectModel(Admin.name) private readonly model: Model<AdminEntity>,
+  ) {}
+
+  public toDomain(adminEntity: AdminEntity): Admin {
     if (!adminEntity) return null;
 
     const admin = new Admin(
@@ -17,16 +26,18 @@ export class AdminMapper {
     return admin;
   }
 
-  public static toPersistence(admin: Admin): AdminEntity {
-    const adminEntity = new AdminEntity(
-      admin.id,
-      admin.email,
-      admin.password,
-      admin.createdAt,
-      admin.updatedAt,
-      admin.getAuthToken(),
-    );
+  public toDomains(adminEntities: AdminEntity[]): Admin[] {
+    return adminEntities.map((adminEntity) => this.toDomain(adminEntity));
+  }
 
-    return adminEntity;
+  public toPersistence(admin: Admin): AdminEntity {
+    return new this.model({
+      id: admin.id,
+      email: admin.email,
+      password: admin.password,
+      createdAt: admin.createdAt,
+      updatedAt: admin.updatedAt,
+      authToken: admin.getAuthToken(),
+    });
   }
 }

--- a/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { AuthSendLogRepository } from '@application/port/out/auth/auth-send-log.repository';
-import { AuthSendLog, AuthSendLogStatus } from '@domain/auth/auth-send-log';
+import { AuthSendLog } from '@domain/auth/auth-send-log';
 import { Auth } from '@domain/auth/auth';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';

--- a/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
@@ -1,18 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { AuthSendLogRepository } from '@application/port/out/auth/auth-send-log.repository';
-import { AuthSendLog } from '@domain/auth/auth-send-log';
+import { AuthSendLog, AuthSendLogStatus } from '@domain/auth/auth-send-log';
 import { Auth } from '@domain/auth/auth';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { AuthSendLogEntity } from '@adapter/out/persistence/auth/schema/auth-send-log.schema';
 import { AuthSendLogMapper } from '@adapter/out/persistence/auth/mapper/auth-send-log.mapper';
+import { Repository } from '@adapter/out/persistence/repository';
+import { transactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
 
 @Injectable()
-export class AuthSendLogMongoRepository implements AuthSendLogRepository {
+export class AuthSendLogMongoRepository
+  extends Repository<AuthSendLogEntity, AuthSendLog>
+  implements AuthSendLogRepository
+{
   constructor(
     @InjectModel('AuthSendLog')
     private readonly authSendLogModel: Model<AuthSendLogEntity>,
-  ) {}
+    private readonly authSendLogMapper: AuthSendLogMapper,
+  ) {
+    super(authSendLogModel, authSendLogMapper, transactionSessionStorage);
+  }
 
   async createAuthSendLog(
     auth: Auth,
@@ -23,7 +31,7 @@ export class AuthSendLogMongoRepository implements AuthSendLogRepository {
       phoneNumber,
     });
 
-    return AuthSendLogMapper.toDomain(authSendLog);
+    return this.authSendLogMapper.toDomain(authSendLog);
   }
 
   async getAuthSendLogCount(phoneNumber: string): Promise<number> {
@@ -40,13 +48,18 @@ export class AuthSendLogMongoRepository implements AuthSendLogRepository {
           $lt: today,
         },
       })
+      .session(this.getSession())
       .exec();
   }
 
   async getLatestAuthSendLog(phoneNumber: string): Promise<AuthSendLog> {
-    return AuthSendLogMapper.toDomain(
+    return this.authSendLogMapper.toDomain(
       await this.authSendLogModel
-        .findOne({ phoneNumber }, {}, { sort: { sentAt: -1 } })
+        .findOne(
+          { phoneNumber },
+          {},
+          { sort: { sentAt: -1 }, session: this.getSession() },
+        )
         .exec(),
     );
   }

--- a/src/adapter/out/persistence/auth/invitation/mapper/invitation.mapper.ts
+++ b/src/adapter/out/persistence/auth/invitation/mapper/invitation.mapper.ts
@@ -1,8 +1,20 @@
 import { Invitation } from '@domain/auth/invitation';
 import { InvitationEntity } from '@adapter/out/persistence/auth/invitation/schema/invitation.schema';
+import { Injectable } from '@nestjs/common';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 
-export class InvitationMapper {
-  public static toDomain(invitationEntity: InvitationEntity): Invitation {
+@Injectable()
+export class InvitationMapper
+  implements MapperPort<InvitationEntity, Invitation>
+{
+  constructor(
+    @InjectModel(Invitation.name)
+    private readonly model: Model<InvitationEntity>,
+  ) {}
+
+  public toDomain(invitationEntity: InvitationEntity): Invitation {
     if (!invitationEntity) return null;
 
     const invitation = new Invitation(
@@ -18,16 +30,20 @@ export class InvitationMapper {
     return invitation;
   }
 
-  public static toPersistence(invitation: Invitation): InvitationEntity {
-    const invitationEntity = new InvitationEntity(
-      invitation.id,
-      invitation.invitationType,
-      invitation.inviterId,
-      invitation.invitationCode,
-      invitation.inviteePhoneNumber,
-      invitation.getInvitationStatus(),
+  public toDomains(invitationEntities: InvitationEntity[]): Invitation[] {
+    return invitationEntities.map((invitationEntity) =>
+      this.toDomain(invitationEntity),
     );
+  }
 
-    return invitationEntity;
+  public toPersistence(invitation: Invitation): InvitationEntity {
+    return new this.model({
+      id: invitation.id,
+      invitationType: invitation.invitationType,
+      inviterId: invitation.inviterId,
+      invitationCode: invitation.invitationCode,
+      inviteePhoneNumber: invitation.inviteePhoneNumber,
+      invitationStatus: invitation.getInvitationStatus(),
+    });
   }
 }

--- a/src/adapter/out/persistence/auth/mapper/auth-send-log.mapper.ts
+++ b/src/adapter/out/persistence/auth/mapper/auth-send-log.mapper.ts
@@ -1,8 +1,20 @@
 import { AuthSendLogEntity } from '@adapter/out/persistence/auth/schema/auth-send-log.schema';
 import { AuthSendLog } from '@domain/auth/auth-send-log';
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { MapperPort } from '@application/port/out/mapper.port';
 
-export class AuthSendLogMapper {
-  public static toDomain(authSendLogEntity: AuthSendLogEntity): AuthSendLog {
+@Injectable()
+export class AuthSendLogMapper
+  implements MapperPort<AuthSendLogEntity, AuthSendLog>
+{
+  constructor(
+    @InjectModel(AuthSendLog.name)
+    private readonly model: Model<AuthSendLogEntity>,
+  ) {}
+
+  public toDomain(authSendLogEntity: AuthSendLogEntity): AuthSendLog {
     if (!authSendLogEntity) return null;
 
     const authSendLog = new AuthSendLog(
@@ -15,22 +27,18 @@ export class AuthSendLogMapper {
     return authSendLog;
   }
 
-  public static toDomains(
-    authSendLogEntities: AuthSendLogEntity[],
-  ): AuthSendLog[] {
+  public toDomains(authSendLogEntities: AuthSendLogEntity[]): AuthSendLog[] {
     return authSendLogEntities.map((authSendLogEntity) =>
       this.toDomain(authSendLogEntity),
     );
   }
 
-  public static toPersistence(authSendLog: AuthSendLog): AuthSendLogEntity {
-    const authSendLogEntity = new AuthSendLogEntity(
-      authSendLog.id,
-      authSendLog.authId,
-      authSendLog.phoneNumber,
-      authSendLog.sentAt,
-    );
-
-    return authSendLogEntity;
+  public toPersistence(authSendLog: AuthSendLog): AuthSendLogEntity {
+    return new this.model({
+      id: authSendLog.id,
+      authId: authSendLog.authId,
+      phoneNumber: authSendLog.phoneNumber,
+      sentAt: authSendLog.sentAt,
+    });
   }
 }

--- a/src/adapter/out/persistence/auth/mapper/auth.mapper.ts
+++ b/src/adapter/out/persistence/auth/mapper/auth.mapper.ts
@@ -1,8 +1,17 @@
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
 import { AuthEntity } from '@adapter/out/persistence/auth/schema/auth.schema';
 import { Auth } from '@domain/auth/auth';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { Injectable } from '@nestjs/common';
 
-export class AuthMapper {
-  public static toDomain(authEntity: AuthEntity): Auth {
+@Injectable()
+export class AuthMapper implements MapperPort<AuthEntity, Auth> {
+  constructor(
+    @InjectModel(Auth.name) private readonly model: Model<AuthEntity>,
+  ) {}
+
+  public toDomain(authEntity: AuthEntity): Auth {
     if (!authEntity) return null;
 
     const auth = new Auth(
@@ -17,20 +26,18 @@ export class AuthMapper {
     return auth;
   }
 
-  public static toDomains(authEntities: AuthEntity[]): Auth[] {
+  public toDomains(authEntities: AuthEntity[]): Auth[] {
     return authEntities.map((authEntity) => this.toDomain(authEntity));
   }
 
-  public static toPersistence(auth: Auth): AuthEntity {
-    const authEntity = new AuthEntity(
-      auth.id,
-      auth.phoneNumber,
-      auth.authCode,
-      auth.createdAt,
-      auth.verified,
-      auth.verifiedAt,
-    );
-
-    return authEntity;
+  public toPersistence(auth: Auth): AuthEntity {
+    return new this.model({
+      id: auth.id,
+      phoneNumber: auth.phoneNumber,
+      authCode: auth.authCode,
+      createdAt: auth.createdAt,
+      verified: auth.verified,
+      verifiedAt: auth.verifiedAt,
+    });
   }
 }

--- a/src/adapter/out/persistence/common/transaction/transaction.manager.ts
+++ b/src/adapter/out/persistence/common/transaction/transaction.manager.ts
@@ -1,0 +1,18 @@
+import { Connection } from 'mongoose';
+import { InjectConnection } from '@nestjs/mongoose';
+
+export class TransactionManager {
+  private static instance: TransactionManager;
+
+  constructor(@InjectConnection() private readonly connection: Connection) {
+    TransactionManager.instance = this;
+  }
+
+  static getInstance(): TransactionManager {
+    return TransactionManager.instance;
+  }
+
+  getConnection(): Connection {
+    return this.connection;
+  }
+}

--- a/src/adapter/out/persistence/common/transaction/transaction.session.storage.ts
+++ b/src/adapter/out/persistence/common/transaction/transaction.session.storage.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { ClientSession } from 'mongoose';
+
+// docs: https://nodejs.org/docs/latest-v18.x/api/async_context.html
+export class TransactionSessionStorage {
+  private sessionStorage: AsyncLocalStorage<ClientSession>;
+
+  constructor() {
+    this.sessionStorage = new AsyncLocalStorage();
+  }
+
+  setTransaction(session: ClientSession): void {
+    this.sessionStorage.enterWith(session);
+  }
+
+  getTransaction(): ClientSession {
+    return this.sessionStorage.getStore();
+  }
+}
+
+export const transactionSessionStorage = new TransactionSessionStorage();

--- a/src/adapter/out/persistence/repositories.module.ts
+++ b/src/adapter/out/persistence/repositories.module.ts
@@ -12,6 +12,16 @@ import { InvitationSchema } from '@adapter/out/persistence/auth/invitation/schem
 import { AdminSchema } from '@adapter/out/persistence/admin/schema/admin.schema';
 import { AdminMongoRepository } from '@adapter/out/persistence/admin/admin.mongo.repository';
 import { InvitationMongoRepository } from '@adapter/out/persistence/auth/invitation/invitation.mongo.repository';
+import { UserMapper } from '@adapter/out/persistence/user/mapper/user.mapper';
+import { User } from '@domain/user/user';
+import { Auth } from '@domain/auth/auth';
+import { AuthSendLog } from '@domain/auth/auth-send-log';
+import { Admin } from '@domain/admin/admin';
+import { Invitation } from '@domain/auth/invitation';
+import { AuthMapper } from '@adapter/out/persistence/auth/mapper/auth.mapper';
+import { AuthSendLogMapper } from '@adapter/out/persistence/auth/mapper/auth-send-log.mapper';
+import { InvitationMapper } from '@adapter/out/persistence/auth/invitation/mapper/invitation.mapper';
+import { AdminMapper } from '@adapter/out/persistence/admin/mapper/admin.mapper';
 
 @Module({
   imports: [
@@ -23,18 +33,23 @@ import { InvitationMongoRepository } from '@adapter/out/persistence/auth/invitat
       }),
     }),
     MongooseModule.forFeature([
-      { name: 'User', schema: UserSchema },
-      { name: 'Auth', schema: AuthSchema },
-      { name: 'AuthSendLog', schema: AuthSendLogSchema },
-      { name: 'Admin', schema: AdminSchema },
-      { name: 'Invitation', schema: InvitationSchema },
+      { name: User.name, schema: UserSchema },
+      { name: Auth.name, schema: AuthSchema },
+      { name: AuthSendLog.name, schema: AuthSendLogSchema },
+      { name: Admin.name, schema: AdminSchema },
+      { name: Invitation.name, schema: InvitationSchema },
     ]),
   ],
   providers: [
+    UserMapper,
     UserMongoRepository,
+    AuthMapper,
     AuthMongoRepository,
+    AuthSendLogMapper,
     AuthSendLogMongoRepository,
+    InvitationMapper,
     InvitationMongoRepository,
+    AdminMapper,
     AdminMongoRepository,
   ],
   exports: [

--- a/src/adapter/out/persistence/repository.ts
+++ b/src/adapter/out/persistence/repository.ts
@@ -1,0 +1,62 @@
+import { ClientSession, Document, Model } from 'mongoose';
+import {
+  Paginated,
+  PaginatedQueryParams,
+  RepositoryPort,
+} from '@application/port/out/repository.port';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { Domain } from '@domain/domain';
+import { TransactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
+
+export abstract class Repository<
+  Entity extends Document,
+  DomainType extends Domain,
+> implements RepositoryPort<DomainType>
+{
+  protected constructor(
+    private readonly model: Model<Entity>,
+    private readonly mapper: MapperPort<Entity, DomainType>,
+    protected readonly transactionSessionStorage: TransactionSessionStorage,
+  ) {}
+
+  protected getSession(): ClientSession {
+    return this.transactionSessionStorage.getTransaction();
+  }
+
+  async findById(id: any): Promise<DomainType> {
+    return this.mapper.toDomain(await this.model.findById(id).exec());
+  }
+
+  async findMany(): Promise<DomainType[]> {
+    return this.mapper.toDomains(await this.model.find({}).limit(10).exec());
+  }
+
+  async findManyPaginated(
+    params: PaginatedQueryParams,
+  ): Promise<Paginated<DomainType>> {
+    const domains = this.mapper.toDomains(
+      await this.model.find({}).skip(params.page).limit(params.limit).exec(),
+    );
+
+    return new Paginated({
+      data: domains,
+      count: domains.length,
+      limit: params.limit,
+      page: params.page,
+    });
+  }
+
+  async insert(DomainType: DomainType): Promise<void> {
+    await this.save(DomainType);
+  }
+
+  async delete(DomainType: DomainType): Promise<boolean> {
+    const result = await this.model.deleteOne({ _id: DomainType.id });
+    return result.deletedCount > 0;
+  }
+
+  async save(DomainType: DomainType): Promise<void> {
+    const entity = this.mapper.toPersistence(DomainType);
+    await entity.save({ session: this.getSession() });
+  }
+}

--- a/src/adapter/out/persistence/user/mapper/user.mapper.ts
+++ b/src/adapter/out/persistence/user/mapper/user.mapper.ts
@@ -1,9 +1,19 @@
 import { User } from '@domain/user/user';
 import { UserEntity } from '@adapter/out/persistence/user/schema/user.schema';
 import { UserInfo } from '@domain/user/user-info';
+import { Injectable } from '@nestjs/common';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
 
-export class UserMapper {
-  public static toDomain(userEntity: UserEntity): User {
+// TODO Mapper가 과연 Injectable하게 선언되어야하는가?
+@Injectable()
+export class UserMapper implements MapperPort<UserEntity, User> {
+  constructor(
+    @InjectModel(User.name) private readonly model: Model<UserEntity>,
+  ) {}
+
+  public toDomain(userEntity: UserEntity): User {
     if (!userEntity) return null;
 
     const user = new User(
@@ -23,24 +33,24 @@ export class UserMapper {
     return user;
   }
 
-  public static toDomains(userEntities: UserEntity[]): User[] {
+  public toDomains(userEntities: UserEntity[]): User[] {
     return userEntities.map((userEntity) => this.toDomain(userEntity));
   }
 
-  public static toPersistence(user: User): UserEntity {
-    return new UserEntity(
-      user.id,
-      user.getNickname(),
-      user.getUserInfo(),
-      user.phoneNumber,
-      user.createdAt,
-      user.updatedAt,
+  public toPersistence(user: User): UserEntity {
+    return new this.model({
+      id: user.id,
+      nickname: user.getNickname(),
+      userInfo: user.getUserInfo(),
+      phoneNumber: user.phoneNumber,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
 
-      user.getLocation(),
-      user.getLocationUpdatedAt(),
-      user.getVerifiedAt(),
-      user.getAuthToken(),
-      user.getDeletedAt(),
-    );
+      location: user.getLocation(),
+      locationUpdatedAt: user.getLocationUpdatedAt(),
+      verifiedAt: user.getVerifiedAt(),
+      authToken: user.getAuthToken(),
+      deletedAt: user.getDeletedAt(),
+    });
   }
 }

--- a/src/adapter/out/persistence/user/user.mongo.repository.ts
+++ b/src/adapter/out/persistence/user/user.mongo.repository.ts
@@ -3,26 +3,34 @@ import { User } from '@domain/user/user';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Injectable } from '@nestjs/common';
-import { UserMapper } from '@adapter/out/persistence/user/mapper/user.mapper';
 import { UserEntity } from '@adapter/out/persistence/user/schema/user.schema';
 import { SignUpDetails } from '@application/port/in/auth/command/auth.command';
 import { AuthToken } from '@domain/user/auth-token';
 import { TokenRepository } from '@application/port/out/auth/token.repository';
+import { UserMapper } from '@adapter/out/persistence/user/mapper/user.mapper';
+import { Repository } from '@adapter/out/persistence/repository';
+import { transactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
 
 @Injectable()
 export class UserMongoRepository
+  extends Repository<UserEntity, User>
   implements UserRepository, TokenRepository<User>
 {
   constructor(
-    @InjectModel('User') private readonly userModel: Model<UserEntity>,
-  ) {}
+    @InjectModel(User.name) private readonly userModel: Model<UserEntity>,
+    private readonly userMapper: UserMapper,
+  ) {
+    super(userModel, userMapper, transactionSessionStorage);
+  }
 
   async getById(userId: string): Promise<User | null> {
-    return UserMapper.toDomain(await this.userModel.findById(userId).exec());
+    return this.userMapper.toDomain(
+      await this.userModel.findById(userId).exec(),
+    );
   }
 
   async getUserByPhoneNumber(phoneNumber: string): Promise<User | null> {
-    return UserMapper.toDomain(
+    return this.userMapper.toDomain(
       await this.userModel
         .findOne({
           phoneNumber,
@@ -49,7 +57,7 @@ export class UserMongoRepository
   }
 
   async userSignUp(signUpDetails: SignUpDetails): Promise<User> {
-    return UserMapper.toDomain(
+    return this.userMapper.toDomain(
       await this.userModel.create({
         ...signUpDetails,
         userInfo: {},
@@ -61,7 +69,7 @@ export class UserMongoRepository
     userId: string,
     authToken: AuthToken,
   ): Promise<User> {
-    return UserMapper.toDomain(
+    return this.userMapper.toDomain(
       await this.userModel.findByIdAndUpdate(userId, {
         authToken: authToken,
       }),

--- a/src/application/port/out/mapper.port.ts
+++ b/src/application/port/out/mapper.port.ts
@@ -1,0 +1,9 @@
+import { Domain } from '@domain/domain';
+
+export interface MapperPort<Entity, DomainType extends Domain> {
+  toDomain(entity: Entity): DomainType;
+
+  toDomains(entities: Entity[]): DomainType[];
+
+  toPersistence(DomainType: DomainType): Entity;
+}

--- a/src/application/port/out/repository.port.ts
+++ b/src/application/port/out/repository.port.ts
@@ -35,9 +35,9 @@ export interface RepositoryPort<DomainType extends Domain> {
     params: PaginatedQueryParams,
   ): Promise<Paginated<DomainType>>;
 
-  insert(DomainType: DomainType): Promise<void>;
+  insert(domain: DomainType): Promise<void>;
 
-  delete(DomainType: DomainType): Promise<boolean>;
+  delete(domain: DomainType): Promise<boolean>;
 
-  save(DomainType: DomainType): Promise<void>;
+  save(domain: DomainType): Promise<void>;
 }

--- a/src/application/port/out/repository.port.ts
+++ b/src/application/port/out/repository.port.ts
@@ -1,0 +1,43 @@
+import { Domain } from '@domain/domain';
+
+export type PaginatedQueryParams = {
+  page: number;
+  limit: number;
+  offset: number;
+  count: number;
+};
+
+export class Paginated<T> {
+  readonly count: number;
+  readonly limit: number;
+  readonly page: number;
+  readonly data: readonly T[];
+
+  constructor(props: Paginated<T>) {
+    this.count = props.count;
+    this.limit = props.limit;
+    this.page = props.page;
+    this.data = props.data;
+  }
+}
+
+export type OrderBy = {
+  field: string | true;
+  param: 'asc' | 'desc';
+};
+
+export interface RepositoryPort<DomainType extends Domain> {
+  findById(id: any): Promise<DomainType>;
+
+  findMany(): Promise<DomainType[]>;
+
+  findManyPaginated(
+    params: PaginatedQueryParams,
+  ): Promise<Paginated<DomainType>>;
+
+  insert(DomainType: DomainType): Promise<void>;
+
+  delete(DomainType: DomainType): Promise<boolean>;
+
+  save(DomainType: DomainType): Promise<void>;
+}

--- a/src/common/decorator/transactional.decorator.ts
+++ b/src/common/decorator/transactional.decorator.ts
@@ -18,9 +18,7 @@ export function Transactional() {
       }
 
       const session = await connection.startSession();
-      const session2 = await connection.startSession();
       transactionSessionStorage.setTransaction(session);
-      await session2.endSession();
 
       try {
         session.startTransaction();

--- a/src/common/decorator/transactional.decorator.ts
+++ b/src/common/decorator/transactional.decorator.ts
@@ -1,0 +1,39 @@
+import { TransactionManager } from '@adapter/out/persistence/common/transaction/transaction.manager';
+import { transactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
+
+export function Transactional() {
+  return function (
+    target: any,
+    propertyName: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: any[]) {
+      const transactionManager = TransactionManager.getInstance();
+      const connection = transactionManager.getConnection();
+
+      if (transactionSessionStorage.getTransaction()) {
+        await originalMethod.apply(this, args);
+      }
+
+      const session = await connection.startSession();
+      const session2 = await connection.startSession();
+      transactionSessionStorage.setTransaction(session);
+      await session2.endSession();
+
+      try {
+        session.startTransaction();
+        await originalMethod.apply(this, args);
+        await session.commitTransaction();
+      } catch (err) {
+        await session.abortTransaction();
+        throw err;
+      } finally {
+        await session.endSession();
+      }
+    };
+
+    return descriptor;
+  };
+}

--- a/src/common/decorator/transactional.decorator.ts
+++ b/src/common/decorator/transactional.decorator.ts
@@ -1,3 +1,4 @@
+// TODO: Custom Decorator가 Nest.js의 의존성을 가지고 있는 것은 Clean Architecutre의 의도에 부합하지 않음
 import { TransactionManager } from '@adapter/out/persistence/common/transaction/transaction.manager';
 import { transactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
 

--- a/src/domain/admin/admin.ts
+++ b/src/domain/admin/admin.ts
@@ -1,7 +1,8 @@
 import { AuthToken } from '@domain/user/auth-token';
 import { Accountable } from '@domain/auth/accountable';
+import { Domain } from '@domain/domain';
 
-export class Admin implements Accountable {
+export class Admin extends Domain implements Accountable {
   public readonly id: string;
   public readonly email: string;
   public readonly password: string;
@@ -18,6 +19,8 @@ export class Admin implements Accountable {
     updatedAt: Date = new Date(),
     authToken: AuthToken = null,
   ) {
+    super();
+
     this.id = id;
     this.email = email;
     this.password = password;

--- a/src/domain/auth/auth-send-log.ts
+++ b/src/domain/auth/auth-send-log.ts
@@ -1,4 +1,6 @@
-export class AuthSendLog {
+import { Domain } from '@domain/domain';
+
+export class AuthSendLog extends Domain {
   id?: string;
 
   authId: string;
@@ -8,6 +10,8 @@ export class AuthSendLog {
   sentAt: Date;
 
   constructor(id: string, authId: string, phoneNumber: string, sentAt: Date) {
+    super();
+
     this.id = id;
     this.authId = authId;
     this.phoneNumber = phoneNumber;

--- a/src/domain/auth/auth.ts
+++ b/src/domain/auth/auth.ts
@@ -1,4 +1,6 @@
-export class Auth {
+import { Domain } from '@domain/domain';
+
+export class Auth extends Domain {
   readonly id: string;
 
   readonly phoneNumber: string;
@@ -19,6 +21,8 @@ export class Auth {
     verified = false,
     verifiedAt: Date,
   ) {
+    super();
+
     this.id = id;
     this.phoneNumber = phoneNumber;
     this.authCode = authCode;

--- a/src/domain/auth/invitation.ts
+++ b/src/domain/auth/invitation.ts
@@ -1,3 +1,5 @@
+import { Domain } from '@domain/domain';
+
 export enum InvitationType {
   ADMIN = 'ADMIN',
   USER = 'USER',
@@ -9,7 +11,7 @@ export enum InvitationStatus {
   REJECTED = 'REJECTED',
 }
 
-export class Invitation {
+export class Invitation extends Domain {
   id: string;
   readonly invitationType: InvitationType;
   readonly inviterId: string;
@@ -24,6 +26,8 @@ export class Invitation {
     invitationCode: string,
     inviteePhoneNumber: string = null,
   ) {
+    super();
+
     this.id = null;
     this.invitationType = invitationType;
     this.inviterId = inviterId;

--- a/src/domain/domain.ts
+++ b/src/domain/domain.ts
@@ -1,0 +1,3 @@
+export abstract class Domain {
+  id?: string | number;
+}

--- a/src/domain/user/user.ts
+++ b/src/domain/user/user.ts
@@ -3,8 +3,9 @@ import { AuthToken } from '@domain/user/auth-token';
 import { UserInfo } from '@domain/user/user-info';
 import { InvalidPhoneNumberFormatException } from '@domain/user/exception/invalid-phone-number-format.exception';
 import { Accountable } from '@domain/auth/accountable';
+import { Domain } from '@domain/domain';
 
-export class User implements Accountable {
+export class User extends Domain implements Accountable {
   readonly id?: string;
   readonly phoneNumber: string;
   readonly createdAt: Date;
@@ -27,6 +28,8 @@ export class User implements Accountable {
     updatedAt: Date,
     authToken: AuthToken = null,
   ) {
+    super();
+
     this.id = id;
     this.nickname = nickname;
     this.userInfo = userInfo;

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { ResponseInterceptor } from '@common/interceptor/response.interceptor';
 import { EnvironmentStatus } from '@common/config/environment-config.validation';
 import { getConnectionToken } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -50,8 +51,9 @@ function initInterceptors(app: INestApplication): void {
 }
 
 function initMongoose(app: INestApplication): void {
-  const connection = app.get(getConnectionToken());
-  connection.set('debug', true);
+  const connection: Connection = app.get(getConnectionToken());
+
+  if (process.env.NODE_ENV === 'development') connection.set('debug', true);
 }
 
 function initSwagger(app: INestApplication): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,14 @@ import { LoggerInterceptor } from '@common/interceptor/logger.interceptor';
 import { LoggerAdapter } from '@adapter/common/logger/logger.adapter';
 import { ResponseInterceptor } from '@common/interceptor/response.interceptor';
 import { EnvironmentStatus } from '@common/config/environment-config.validation';
+import { getConnectionToken } from '@nestjs/mongoose';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   initApplication(app);
   initInterceptors(app);
+  initMongoose(app);
   initSwagger(app);
 
   await app.listen(3000);
@@ -45,6 +47,11 @@ function initApplication(app: INestApplication): void {
 function initInterceptors(app: INestApplication): void {
   app.useGlobalInterceptors(new LoggerInterceptor(new LoggerAdapter()));
   app.useGlobalInterceptors(new ResponseInterceptor());
+}
+
+function initMongoose(app: INestApplication): void {
+  const connection = app.get(getConnectionToken());
+  connection.set('debug', true);
 }
 
 function initSwagger(app: INestApplication): void {


### PR DESCRIPTION
## OverView
1. mongoose의 디버그 모드 활성화
   - `NODE_ENV`가 `development` 상태일 때 디버그 모드를 활성화합니다.
2. Domain 개선
   - 추상 `Domain` 클래스를 도입하였고, 모든 도메인은 해당 클래스를 상속받도록 수정하였습니다.
   - `Embedding Document`와 도메인 사이의 구분을 더욱 명확하도록 수정하였습니다.
3. Mapper 리팩토링
   - 모든 Mapper의 구조를 표준화하기 위해, `MapperPort`를 도입하였습니다.
   - 모든 도메인의 Mapper를 **Injectable**하게 관리하도록 개선하였습니다.
   - `toPersistence` 메서드는 이제 주입된 `model`을 기반으로 Entity를 생성합니다.
4. Repository 리팩토링
   - 모든 Repository에 대한 표준을 제공하기 위해 `RepositoryPort`를 도입하였습니다.
   - 모든 도메인의 Repository는 `Repository` 구현체를 상속받아, Entity 및 Domain을 정의합니다.
5. Transaction Session Storage 및 Transactional 데코레이터 구현
   - `node:async_hooks`을 이용해 비동기 요청마다 `Transaction Session` 정보를 관리하는 세션 스토리지를 구현하였습니다.
   - Application 계층에서 사용할 `Transactional` 커스텀 데코레이터를 도입하였습니다.

## Next
1. `Transactional` 데코레이터의 의존성 수정이 필요합니다.
   - Application 계층에서 사용될 때, Adapter 계층에 대한 의존을 피해야합니다.
2. Mapper를 **Injectable**하게 관리하지 않도록 수정해야합니다.

