### PR TITLE
feat(Region): Design and Implementation of Region Domain, Repository Enhancements

### DIFF
--- a/src/adapter/adapter.module.ts
+++ b/src/adapter/adapter.module.ts
@@ -6,6 +6,7 @@ import { SnsModule } from '@adapter/out/messaging/sns/sns.module';
 import { AuthController } from '@adapter/in/web/auth/auth.controller';
 import { ServiceProxyModule } from '@adapter/in/web/service-proxy/service-proxy.module';
 import { AdminController } from '@adapter/in/web/admin/admin.controller';
+import { RegionController } from '@adapter/in/web/region/region.controller';
 
 @Module({
   imports: [
@@ -14,7 +15,12 @@ import { AdminController } from '@adapter/in/web/admin/admin.controller';
     RepositoriesModule,
     ServiceProxyModule,
   ],
-  controllers: [AuthController, UserController, AdminController],
+  controllers: [
+    AuthController,
+    UserController,
+    AdminController,
+    RegionController,
+  ],
   providers: [],
   exports: [ServiceProxyModule],
 })

--- a/src/adapter/in/web/region/region.controller.ts
+++ b/src/adapter/in/web/region/region.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Inject, Query } from '@nestjs/common';
+import {
+  GET_REGION_EXACT_LOCATION_QUERY,
+  GetRegionExactLocationQuery,
+} from '@application/port/in/region/get-region-exact-location.query';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UserPresenter } from '@adapter/in/web/user/user.presenter';
+import { GetRegionDto } from '@adapter/in/web/region/region.dto';
+import { RegionPresenter } from '@adapter/in/web/region/region.presenter';
+
+@Controller('region')
+@ApiTags('users')
+@ApiResponse({ status: 500, description: 'Internal error' })
+@ApiExtraModels(UserPresenter)
+export class RegionController {
+  constructor(
+    @Inject(GET_REGION_EXACT_LOCATION_QUERY)
+    private readonly getRegionExactLocationQuery: GetRegionExactLocationQuery,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get Region' })
+  @ApiResponse({
+    status: 200,
+    description: 'Return Region',
+    type: [RegionPresenter],
+  })
+  async getRegion(@Query() query: GetRegionDto): Promise<RegionPresenter> {
+    return new RegionPresenter(
+      await this.getRegionExactLocationQuery.exec(query),
+    );
+  }
+}

--- a/src/adapter/in/web/region/region.controller.ts
+++ b/src/adapter/in/web/region/region.controller.ts
@@ -14,7 +14,7 @@ import { GetRegionDto } from '@adapter/in/web/region/region.dto';
 import { RegionPresenter } from '@adapter/in/web/region/region.presenter';
 
 @Controller('region')
-@ApiTags('users')
+@ApiTags('region')
 @ApiResponse({ status: 500, description: 'Internal error' })
 @ApiExtraModels(UserPresenter)
 export class RegionController {

--- a/src/adapter/in/web/region/region.dto.ts
+++ b/src/adapter/in/web/region/region.dto.ts
@@ -1,0 +1,25 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetRegionDto {
+  @ApiProperty({
+    example: '서울특별시',
+    description: "지역의 '시도'",
+  })
+  @IsString()
+  city: string;
+
+  @ApiProperty({
+    example: '강남구',
+    description: "지역의 '시군구'",
+  })
+  @IsString()
+  district: string;
+
+  @ApiProperty({
+    example: '삼성동',
+    description: "지역의 '읍면동'",
+  })
+  @IsString()
+  neighborhood: string;
+}

--- a/src/adapter/in/web/region/region.presenter.ts
+++ b/src/adapter/in/web/region/region.presenter.ts
@@ -28,8 +28,8 @@ export class RegionPresenter {
 
   constructor(region: Region) {
     this.id = region.id;
-    this.city = region.city;
-    this.district = region.district;
-    this.neighborhood = region.neighborhood;
+    this.city = region.getCity();
+    this.district = region.getDistrict();
+    this.neighborhood = region.getNeighborhood();
   }
 }

--- a/src/adapter/in/web/region/region.presenter.ts
+++ b/src/adapter/in/web/region/region.presenter.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Region } from '@domain/region/region';
+
+export class RegionPresenter {
+  @ApiProperty({
+    example: '649ce895f331996dcc3cddb6',
+    description: 'id',
+  })
+  id?: string;
+
+  @ApiProperty({
+    example: '서울특별시',
+    description: "지역의 '시도'",
+  })
+  city: string;
+
+  @ApiProperty({
+    example: '강남구',
+    description: "지역의 '시군구'",
+  })
+  district: string;
+
+  @ApiProperty({
+    example: '삼성동',
+    description: "지역의 '읍면동'",
+  })
+  neighborhood: string;
+
+  constructor(region: Region) {
+    this.id = region.id;
+    this.city = region.city;
+    this.district = region.district;
+    this.neighborhood = region.neighborhood;
+  }
+}

--- a/src/adapter/in/web/service-proxy/region.service-proxy.module.ts
+++ b/src/adapter/in/web/service-proxy/region.service-proxy.module.ts
@@ -1,0 +1,25 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { CREATE_REGION_USECASE } from '@application/port/in/region/create-region.usecase';
+import { RegionMongoRepository } from '@adapter/out/persistence/region/region.mongo.repository';
+import { RepositoriesModule } from '@adapter/out/persistence/repositories.module';
+import { CreateRegionService } from '@application/service/region/create-region.service';
+
+@Module({
+  imports: [RepositoriesModule],
+})
+export class RegionServiceProxyModule {
+  static register(): DynamicModule {
+    return {
+      module: RegionServiceProxyModule,
+      providers: [
+        {
+          inject: [RegionMongoRepository],
+          provide: CREATE_REGION_USECASE,
+          useFactory: (regionMongoRepository: RegionMongoRepository) =>
+            new CreateRegionService(regionMongoRepository),
+        },
+      ],
+      exports: [CREATE_REGION_USECASE],
+    };
+  }
+}

--- a/src/adapter/in/web/service-proxy/region.service-proxy.module.ts
+++ b/src/adapter/in/web/service-proxy/region.service-proxy.module.ts
@@ -3,6 +3,8 @@ import { CREATE_REGION_USECASE } from '@application/port/in/region/create-region
 import { RegionMongoRepository } from '@adapter/out/persistence/region/region.mongo.repository';
 import { RepositoriesModule } from '@adapter/out/persistence/repositories.module';
 import { CreateRegionService } from '@application/service/region/create-region.service';
+import { GET_REGION_EXACT_LOCATION_QUERY } from '@application/port/in/region/get-region-exact-location.query';
+import { GetRegionExactLocationService } from '@application/service/region/get-region-exact-location.service';
 
 @Module({
   imports: [RepositoriesModule],
@@ -18,8 +20,14 @@ export class RegionServiceProxyModule {
           useFactory: (regionMongoRepository: RegionMongoRepository) =>
             new CreateRegionService(regionMongoRepository),
         },
+        {
+          inject: [RegionMongoRepository],
+          provide: GET_REGION_EXACT_LOCATION_QUERY,
+          useFactory: (regionMongoRepository: RegionMongoRepository) =>
+            new GetRegionExactLocationService(regionMongoRepository),
+        },
       ],
-      exports: [CREATE_REGION_USECASE],
+      exports: [CREATE_REGION_USECASE, GET_REGION_EXACT_LOCATION_QUERY],
     };
   }
 }

--- a/src/adapter/in/web/service-proxy/service-proxy.module.ts
+++ b/src/adapter/in/web/service-proxy/service-proxy.module.ts
@@ -4,6 +4,7 @@ import { AuthServiceProxyModule } from '@adapter/in/web/service-proxy/auth.servi
 import { UserServiceProxyModule } from '@adapter/in/web/service-proxy/user.service-proxy.module';
 import { AdminServiceProxyModule } from '@adapter/in/web/service-proxy/admin.service-proxy.module';
 import { InvitationServiceProxyModule } from '@adapter/in/web/service-proxy/invitation.service-proxy.module';
+import { RegionServiceProxyModule } from '@adapter/in/web/service-proxy/region.service-proxy.module';
 
 @Module({
   imports: [
@@ -11,12 +12,14 @@ import { InvitationServiceProxyModule } from '@adapter/in/web/service-proxy/invi
     UserServiceProxyModule.register(),
     InvitationServiceProxyModule.register(),
     AdminServiceProxyModule.register(),
+    RegionServiceProxyModule.register(),
   ],
   exports: [
     AuthServiceProxyModule.register(),
     UserServiceProxyModule.register(),
     InvitationServiceProxyModule.register(),
     AdminServiceProxyModule.register(),
+    RegionServiceProxyModule.register(),
   ],
 })
 export class ServiceProxyModule {}

--- a/src/adapter/in/web/service-proxy/user.service-proxy.module.ts
+++ b/src/adapter/in/web/service-proxy/user.service-proxy.module.ts
@@ -5,9 +5,13 @@ import { UPDATE_USER_INFO_USECASE } from '@application/port/in/user/update-user-
 import { UpdateUserInfoService } from '@application/service/user/update-user-info.service';
 import { GET_USER_QUERY } from '@application/port/in/user/get-user.query';
 import { GetUserService } from '@application/service/user/get-user.service';
+import { RegionMongoRepository } from '@adapter/out/persistence/region/region.mongo.repository';
+import { CREATE_REGION_USECASE } from '@application/port/in/region/create-region.usecase';
+import { CreateRegionService } from '@application/service/region/create-region.service';
+import { RegionServiceProxyModule } from '@adapter/in/web/service-proxy/region.service-proxy.module';
 
 @Module({
-  imports: [RepositoriesModule],
+  imports: [RepositoriesModule, RegionServiceProxyModule.register()],
 })
 export class UserServiceProxyModule {
   static register(): DynamicModule {
@@ -15,10 +19,22 @@ export class UserServiceProxyModule {
       module: UserServiceProxyModule,
       providers: [
         {
-          inject: [UserMongoRepository],
+          inject: [
+            UserMongoRepository,
+            RegionMongoRepository,
+            CREATE_REGION_USECASE,
+          ],
           provide: UPDATE_USER_INFO_USECASE,
-          useFactory: (userRepository: UserMongoRepository) =>
-            new UpdateUserInfoService(userRepository),
+          useFactory: (
+            userRepository: UserMongoRepository,
+            regionMongoRepository: RegionMongoRepository,
+            createRegionService: CreateRegionService,
+          ) =>
+            new UpdateUserInfoService(
+              userRepository,
+              regionMongoRepository,
+              createRegionService,
+            ),
         },
         {
           inject: [UserMongoRepository],

--- a/src/adapter/in/web/user/user.dto.ts
+++ b/src/adapter/in/web/user/user.dto.ts
@@ -35,6 +35,5 @@ export class UpdateUserInfoDto {
     description: '유저의 거주지역',
   })
   @IsOptional()
-  @IsEnum(Region)
   readonly region?: Region;
 }

--- a/src/adapter/out/persistence/admin/admin.mongo.repository.ts
+++ b/src/adapter/out/persistence/admin/admin.mongo.repository.ts
@@ -25,10 +25,12 @@ export class AdminMongoRepository
 
   async signUpAdmin(admin: Admin): Promise<Admin> {
     const createdAdmin = await this.adminModel.create(
-      {
-        email: admin.email,
-        password: admin.password,
-      },
+      [
+        {
+          email: admin.email,
+          password: admin.password,
+        },
+      ],
       { session: this.getSession() },
     );
 

--- a/src/adapter/out/persistence/admin/admin.mongo.repository.ts
+++ b/src/adapter/out/persistence/admin/admin.mongo.repository.ts
@@ -39,7 +39,7 @@ export class AdminMongoRepository
 
   async getById(adminId: string): Promise<Admin | null> {
     return this.adminMapper.toDomain(
-      await this.adminModel.findById(adminId).exec(),
+      await this.adminModel.findById(adminId).session(this.getSession()).exec(),
     );
   }
 
@@ -49,6 +49,7 @@ export class AdminMongoRepository
         .findOne({
           email,
         })
+        .session(this.getSession())
         .exec(),
     );
   }

--- a/src/adapter/out/persistence/admin/admin.mongo.repository.ts
+++ b/src/adapter/out/persistence/admin/admin.mongo.repository.ts
@@ -24,12 +24,15 @@ export class AdminMongoRepository
   }
 
   async signUpAdmin(admin: Admin): Promise<Admin> {
-    return this.adminMapper.toDomain(
-      await this.adminModel.create({
+    const createdAdmin = await this.adminModel.create(
+      {
         email: admin.email,
         password: admin.password,
-      }),
+      },
+      { session: this.getSession() },
     );
+
+    return this.adminMapper.toDomains(createdAdmin)[0];
   }
 
   async getById(adminId: string): Promise<Admin | null> {
@@ -53,9 +56,13 @@ export class AdminMongoRepository
     authToken: AuthToken,
   ): Promise<Admin> {
     return this.adminMapper.toDomain(
-      await this.adminModel.findByIdAndUpdate(adminId, {
-        authToken: authToken,
-      }),
+      await this.adminModel.findByIdAndUpdate(
+        adminId,
+        {
+          authToken: authToken,
+        },
+        { session: this.getSession() },
+      ),
     );
   }
 }

--- a/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
@@ -27,10 +27,12 @@ export class AuthSendLogMongoRepository
     phoneNumber: string,
   ): Promise<AuthSendLog> {
     const createdAuthSendLog = await this.authSendLogModel.create(
-      {
-        authId: auth.id,
-        phoneNumber,
-      },
+      [
+        {
+          authId: auth.id,
+          phoneNumber,
+        },
+      ],
       { session: this.getSession() },
     );
 

--- a/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth-send-log.mongo.repository.ts
@@ -26,12 +26,15 @@ export class AuthSendLogMongoRepository
     auth: Auth,
     phoneNumber: string,
   ): Promise<AuthSendLog> {
-    const authSendLog = await this.authSendLogModel.create({
-      authId: auth.id,
-      phoneNumber,
-    });
+    const createdAuthSendLog = await this.authSendLogModel.create(
+      {
+        authId: auth.id,
+        phoneNumber,
+      },
+      { session: this.getSession() },
+    );
 
-    return this.authSendLogMapper.toDomain(authSendLog);
+    return this.authSendLogMapper.toDomains(createdAuthSendLog)[0];
   }
 
   async getAuthSendLogCount(phoneNumber: string): Promise<number> {

--- a/src/adapter/out/persistence/auth/auth.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth.mongo.repository.ts
@@ -36,9 +36,11 @@ export class AuthMongoRepository
 
   async getAuth(phoneNumber: string): Promise<Auth> {
     return this.authMapper.toDomain(
-      await this.authModel.findOne({
-        phoneNumber,
-      }),
+      await this.authModel
+        .findOne({
+          phoneNumber,
+        })
+        .session(this.getSession()),
     );
   }
 

--- a/src/adapter/out/persistence/auth/auth.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth.mongo.repository.ts
@@ -22,10 +22,12 @@ export class AuthMongoRepository
 
   async createAuth(phoneNumber: string, authCode: string): Promise<Auth> {
     const createdAuth = await this.authModel.create(
-      {
-        phoneNumber,
-        authCode,
-      },
+      [
+        {
+          phoneNumber,
+          authCode,
+        },
+      ],
       { session: this.getSession() },
     );
 

--- a/src/adapter/out/persistence/auth/auth.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/auth.mongo.repository.ts
@@ -21,12 +21,15 @@ export class AuthMongoRepository
   }
 
   async createAuth(phoneNumber: string, authCode: string): Promise<Auth> {
-    const auth = await this.authModel.create({
-      phoneNumber,
-      authCode,
-    });
+    const createdAuth = await this.authModel.create(
+      {
+        phoneNumber,
+        authCode,
+      },
+      { session: this.getSession() },
+    );
 
-    return this.authMapper.toDomain(auth);
+    return this.authMapper.toDomains(createdAuth)[0];
   }
 
   async getAuth(phoneNumber: string): Promise<Auth> {
@@ -51,6 +54,7 @@ export class AuthMongoRepository
               authCode,
             },
           },
+          { session: this.getSession() },
         )
         .exec(),
     );
@@ -67,6 +71,7 @@ export class AuthMongoRepository
             verifiedAt: new Date(),
           },
         },
+        { session: this.getSession() },
       )
       .exec();
 

--- a/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
@@ -44,11 +44,16 @@ export class InvitationMongoRepository
   }
 
   async issueInvitation(invitation: Invitation): Promise<Invitation> {
-    return this.invitationMapper.toDomain(
-      await this.invitationModel.create({
+    const createdInvitation = await this.invitationModel.create(
+      {
         ...invitation,
-      }),
+      },
+      {
+        session: this.getSession(),
+      },
     );
+
+    return this.invitationMapper.toDomains(createdInvitation)[0];
   }
 
   async updateInvitationStatus(
@@ -61,6 +66,9 @@ export class InvitationMongoRepository
       },
       {
         invitationStatus,
+      },
+      {
+        session: this.getSession(),
       },
     );
   }

--- a/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
@@ -26,6 +26,7 @@ export class InvitationMongoRepository
       .findOne({
         inviteePhoneNumber,
       })
+      .session(this.getSession())
       .exec();
 
     return this.invitationMapper.toDomain(invitation);
@@ -38,6 +39,7 @@ export class InvitationMongoRepository
       .findOne({
         invitationCode,
       })
+      .session(this.getSession())
       .exec();
 
     return this.invitationMapper.toDomain(invitation);

--- a/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
+++ b/src/adapter/out/persistence/auth/invitation/invitation.mongo.repository.ts
@@ -45,9 +45,11 @@ export class InvitationMongoRepository
 
   async issueInvitation(invitation: Invitation): Promise<Invitation> {
     const createdInvitation = await this.invitationModel.create(
-      {
-        ...invitation,
-      },
+      [
+        {
+          ...invitation,
+        },
+      ],
       {
         session: this.getSession(),
       },

--- a/src/adapter/out/persistence/region/mapper/region.mapper.ts
+++ b/src/adapter/out/persistence/region/mapper/region.mapper.ts
@@ -31,9 +31,9 @@ export class RegionMapper implements MapperPort<RegionEntity, Region> {
   public toPersistence(region: Region): RegionEntity {
     return new this.model({
       id: region.id,
-      city: region.city,
-      district: region.district,
-      neighborhood: region.neighborhood,
+      city: region.getCity(),
+      district: region.getDistrict(),
+      neighborhood: region.getNeighborhood(),
     });
   }
 }

--- a/src/adapter/out/persistence/region/mapper/region.mapper.ts
+++ b/src/adapter/out/persistence/region/mapper/region.mapper.ts
@@ -1,0 +1,39 @@
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+import { MapperPort } from '@application/port/out/mapper.port';
+import { Injectable } from '@nestjs/common';
+import { RegionEntity } from '@adapter/out/persistence/region/schema/region.schema';
+import { Region } from '@domain/region/region';
+
+@Injectable()
+export class RegionMapper implements MapperPort<RegionEntity, Region> {
+  constructor(
+    @InjectModel(Region.name) private readonly model: Model<RegionEntity>,
+  ) {}
+
+  public toDomain(regionEntity: RegionEntity): Region {
+    if (!regionEntity) return null;
+
+    const region = new Region(
+      regionEntity.id,
+      regionEntity.city,
+      regionEntity.district,
+      regionEntity.neighborhood,
+    );
+
+    return region;
+  }
+
+  public toDomains(authEntities: RegionEntity[]): Region[] {
+    return authEntities.map((regionEntity) => this.toDomain(regionEntity));
+  }
+
+  public toPersistence(region: Region): RegionEntity {
+    return new this.model({
+      id: region.id,
+      city: region.city,
+      district: region.district,
+      neighborhood: region.neighborhood,
+    });
+  }
+}

--- a/src/adapter/out/persistence/region/region.mongo.repository.ts
+++ b/src/adapter/out/persistence/region/region.mongo.repository.ts
@@ -1,0 +1,22 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Injectable } from '@nestjs/common';
+import { Repository } from '@adapter/out/persistence/repository';
+import { transactionSessionStorage } from '@adapter/out/persistence/common/transaction/transaction.session.storage';
+import { Region } from '@domain/region/region';
+import { RegionEntity } from '@adapter/out/persistence/region/schema/region.schema';
+import { RegionMapper } from '@adapter/out/persistence/region/mapper/region.mapper';
+import { RegionRepository } from '@application/port/out/region/region.repository';
+
+@Injectable()
+export class RegionMongoRepository
+  extends Repository<RegionEntity, Region>
+  implements RegionRepository
+{
+  constructor(
+    @InjectModel(Region.name) private readonly regionModel: Model<RegionEntity>,
+    private readonly regionMapper: RegionMapper,
+  ) {
+    super(regionModel, regionMapper, transactionSessionStorage);
+  }
+}

--- a/src/adapter/out/persistence/region/region.mongo.repository.ts
+++ b/src/adapter/out/persistence/region/region.mongo.repository.ts
@@ -29,6 +29,7 @@ export class RegionMongoRepository
           district: props.district,
           neighborhood: props.neighborhood,
         })
+        .session(this.getSession())
         .exec(),
     );
   }

--- a/src/adapter/out/persistence/region/region.mongo.repository.ts
+++ b/src/adapter/out/persistence/region/region.mongo.repository.ts
@@ -7,6 +7,7 @@ import { Region } from '@domain/region/region';
 import { RegionEntity } from '@adapter/out/persistence/region/schema/region.schema';
 import { RegionMapper } from '@adapter/out/persistence/region/mapper/region.mapper';
 import { RegionRepository } from '@application/port/out/region/region.repository';
+import { RegionProps } from '@application/port/out/region/region.types';
 
 @Injectable()
 export class RegionMongoRepository
@@ -18,5 +19,17 @@ export class RegionMongoRepository
     private readonly regionMapper: RegionMapper,
   ) {
     super(regionModel, regionMapper, transactionSessionStorage);
+  }
+
+  async find(props: RegionProps): Promise<Region> {
+    return this.regionMapper.toDomain(
+      await this.regionModel
+        .findOne({
+          city: props.city,
+          district: props.district,
+          neighborhood: props.neighborhood,
+        })
+        .exec(),
+    );
   }
 }

--- a/src/adapter/out/persistence/region/schema/region.schema.ts
+++ b/src/adapter/out/persistence/region/schema/region.schema.ts
@@ -1,0 +1,40 @@
+import { Document } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+export class RegionEntity extends Document {
+  id: string;
+
+  city: string;
+
+  district: string;
+
+  neighborhood: string;
+
+  constructor(
+    id: string,
+    city: string,
+    district: string,
+    neighborhood: string,
+  ) {
+    super();
+
+    this.id = id;
+    this.city = city;
+    this.district = district;
+    this.neighborhood = neighborhood;
+  }
+}
+
+@Schema()
+export class RegionMongoSchema {
+  @Prop({ type: String, required: true })
+  city: string;
+
+  @Prop({ type: String, required: true })
+  district: string;
+
+  @Prop({ type: String, required: true })
+  neighborhood: string;
+}
+
+export const RegionSchema = SchemaFactory.createForClass(RegionMongoSchema);

--- a/src/adapter/out/persistence/repositories.module.ts
+++ b/src/adapter/out/persistence/repositories.module.ts
@@ -26,6 +26,7 @@ import { RegionMapper } from '@adapter/out/persistence/region/mapper/region.mapp
 import { RegionMongoRepository } from '@adapter/out/persistence/region/region.mongo.repository';
 import { Region } from '@domain/region/region';
 import { RegionSchema } from '@adapter/out/persistence/region/schema/region.schema';
+import { TransactionManager } from '@adapter/out/persistence/common/transaction/transaction.manager';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { RegionSchema } from '@adapter/out/persistence/region/schema/region.sche
     ]),
   ],
   providers: [
+    TransactionManager,
     UserMapper,
     UserMongoRepository,
     AuthMapper,

--- a/src/adapter/out/persistence/repositories.module.ts
+++ b/src/adapter/out/persistence/repositories.module.ts
@@ -22,6 +22,10 @@ import { AuthMapper } from '@adapter/out/persistence/auth/mapper/auth.mapper';
 import { AuthSendLogMapper } from '@adapter/out/persistence/auth/mapper/auth-send-log.mapper';
 import { InvitationMapper } from '@adapter/out/persistence/auth/invitation/mapper/invitation.mapper';
 import { AdminMapper } from '@adapter/out/persistence/admin/mapper/admin.mapper';
+import { RegionMapper } from '@adapter/out/persistence/region/mapper/region.mapper';
+import { RegionMongoRepository } from '@adapter/out/persistence/region/region.mongo.repository';
+import { Region } from '@domain/region/region';
+import { RegionSchema } from '@adapter/out/persistence/region/schema/region.schema';
 
 @Module({
   imports: [
@@ -38,6 +42,7 @@ import { AdminMapper } from '@adapter/out/persistence/admin/mapper/admin.mapper'
       { name: AuthSendLog.name, schema: AuthSendLogSchema },
       { name: Admin.name, schema: AdminSchema },
       { name: Invitation.name, schema: InvitationSchema },
+      { name: Region.name, schema: RegionSchema },
     ]),
   ],
   providers: [
@@ -51,6 +56,8 @@ import { AdminMapper } from '@adapter/out/persistence/admin/mapper/admin.mapper'
     InvitationMongoRepository,
     AdminMapper,
     AdminMongoRepository,
+    RegionMapper,
+    RegionMongoRepository,
   ],
   exports: [
     UserMongoRepository,
@@ -58,6 +65,7 @@ import { AdminMapper } from '@adapter/out/persistence/admin/mapper/admin.mapper'
     AuthSendLogMongoRepository,
     InvitationMongoRepository,
     AdminMongoRepository,
+    RegionMongoRepository,
   ],
 })
 export class RepositoriesModule {}

--- a/src/adapter/out/persistence/user/user.mongo.repository.ts
+++ b/src/adapter/out/persistence/user/user.mongo.repository.ts
@@ -59,13 +59,13 @@ export class UserMongoRepository
   }
 
   async userSignUp(signUpDetails: SignUpDetails): Promise<User> {
-    // Model.create 메서드는 2개 이상의 인자가 전달될 경우, 배열로 인식한다.
-    // create<DocContents = AnyKeys<TRawDocType>>(...docs: Array<TRawDocType | DocContents>): Promise<THydratedDocumentType[]>;
     const createdUser = await this.userModel.create(
-      {
-        ...signUpDetails,
-        userInfo: new UserInfo(),
-      },
+      [
+        {
+          ...signUpDetails,
+          userInfo: new UserInfo(),
+        },
+      ],
       { session: this.getSession() },
     );
 

--- a/src/adapter/out/persistence/user/user.mongo.repository.ts
+++ b/src/adapter/out/persistence/user/user.mongo.repository.ts
@@ -26,7 +26,7 @@ export class UserMongoRepository
 
   async getById(userId: string): Promise<User | null> {
     return this.userMapper.toDomain(
-      await this.userModel.findById(userId).exec(),
+      await this.userModel.findById(userId).session(this.getSession()).exec(),
     );
   }
 
@@ -36,6 +36,7 @@ export class UserMongoRepository
         .findOne({
           phoneNumber,
         })
+        .session(this.getSession())
         .exec(),
     );
   }

--- a/src/application/port/in/region/create-region.usecase.ts
+++ b/src/application/port/in/region/create-region.usecase.ts
@@ -1,0 +1,7 @@
+import { CreateRegionCommand } from '@application/port/in/region/region.command';
+
+export interface CreateRegionUsecase {
+  exec(createRegionCommand: CreateRegionCommand): Promise<void>;
+}
+
+export const CREATE_REGION_USECASE = Symbol('CreateRegionUsecase');

--- a/src/application/port/in/region/create-region.usecase.ts
+++ b/src/application/port/in/region/create-region.usecase.ts
@@ -1,7 +1,8 @@
 import { CreateRegionCommand } from '@application/port/in/region/region.command';
+import { Region } from '@domain/region/region';
 
 export interface CreateRegionUsecase {
-  exec(createRegionCommand: CreateRegionCommand): Promise<void>;
+  exec(createRegionCommand: CreateRegionCommand): Promise<Region>;
 }
 
 export const CREATE_REGION_USECASE = Symbol('CreateRegionUsecase');

--- a/src/application/port/in/region/get-region-exact-location.query.ts
+++ b/src/application/port/in/region/get-region-exact-location.query.ts
@@ -1,0 +1,12 @@
+import { GetRegionExactLocationCommand } from '@application/port/in/region/region.command';
+import { Region } from '@domain/region/region';
+
+export interface GetRegionExactLocationQuery {
+  exec(
+    getRegionExactLocationCommand: GetRegionExactLocationCommand,
+  ): Promise<Region>;
+}
+
+export const GET_REGION_EXACT_LOCATION_QUERY = Symbol(
+  'GetRegionExactLocationQuery',
+);

--- a/src/application/port/in/region/region.command.ts
+++ b/src/application/port/in/region/region.command.ts
@@ -5,3 +5,11 @@ export class CreateRegionCommand {
     readonly neighborhood: string,
   ) {}
 }
+
+export class GetRegionExactLocationCommand {
+  constructor(
+    readonly city: string,
+    readonly district: string,
+    readonly neighborhood: string,
+  ) {}
+}

--- a/src/application/port/in/region/region.command.ts
+++ b/src/application/port/in/region/region.command.ts
@@ -1,0 +1,7 @@
+export class CreateRegionCommand {
+  constructor(
+    readonly city: string,
+    readonly district: string,
+    readonly neighborhood: string,
+  ) {}
+}

--- a/src/application/port/in/user/command/update-user-info.command.ts
+++ b/src/application/port/in/user/command/update-user-info.command.ts
@@ -1,5 +1,4 @@
 import { Gender } from '@domain/user/user-info';
-import { Region } from '@domain/region/region';
 
 export class UpdateUserInfoCommand {
   constructor(
@@ -7,6 +6,6 @@ export class UpdateUserInfoCommand {
     readonly nickname?: string,
     readonly gender?: Gender,
     readonly birth?: string,
-    readonly region?: Region,
+    readonly regionId?: string,
   ) {}
 }

--- a/src/application/port/in/user/command/update-user-info.command.ts
+++ b/src/application/port/in/user/command/update-user-info.command.ts
@@ -1,4 +1,5 @@
 import { Gender } from '@domain/user/user-info';
+import { Region } from '@domain/region/region';
 
 export class UpdateUserInfoCommand {
   constructor(
@@ -6,6 +7,6 @@ export class UpdateUserInfoCommand {
     readonly nickname?: string,
     readonly gender?: Gender,
     readonly birth?: string,
-    readonly regionId?: string,
+    readonly region?: Region,
   ) {}
 }

--- a/src/application/port/out/admin/admin.repository.ts
+++ b/src/application/port/out/admin/admin.repository.ts
@@ -1,6 +1,7 @@
 import { Admin } from '@domain/admin/admin';
+import { RepositoryPort } from '@application/port/out/repository.port';
 
-export interface AdminRepository {
+export interface AdminRepository extends RepositoryPort<Admin> {
   signUpAdmin(admin: Admin): Promise<Admin>;
 
   getAdminByEmail(email: string): Promise<Admin | null>;

--- a/src/application/port/out/auth/auth-send-log.repository.ts
+++ b/src/application/port/out/auth/auth-send-log.repository.ts
@@ -1,7 +1,8 @@
 import { Auth } from '@domain/auth/auth';
 import { AuthSendLog } from '@domain/auth/auth-send-log';
+import { RepositoryPort } from '@application/port/out/repository.port';
 
-export interface AuthSendLogRepository {
+export interface AuthSendLogRepository extends RepositoryPort<AuthSendLog> {
   createAuthSendLog(auth: Auth, phoneNumber: string): Promise<AuthSendLog>;
 
   getAuthSendLogCount(phoneNumber: string): Promise<number>;

--- a/src/application/port/out/auth/auth.repository.ts
+++ b/src/application/port/out/auth/auth.repository.ts
@@ -1,6 +1,7 @@
 import { Auth } from '@domain/auth/auth';
+import { RepositoryPort } from '@application/port/out/repository.port';
 
-export interface AuthRepository {
+export interface AuthRepository extends RepositoryPort<Auth> {
   getAuth(phoneNumber: string): Promise<Auth | null>;
 
   createAuth(phoneNumber: string, authCode: string): Promise<Auth>;

--- a/src/application/port/out/auth/invitation/invitation.repository.ts
+++ b/src/application/port/out/auth/invitation/invitation.repository.ts
@@ -1,6 +1,7 @@
 import { Invitation, InvitationStatus } from '@domain/auth/invitation';
+import { RepositoryPort } from '@application/port/out/repository.port';
 
-export interface InvitationRepository {
+export interface InvitationRepository extends RepositoryPort<Invitation> {
   getInvitation(inviteePhoneNumber: string): Promise<Invitation | null>;
 
   getInvitationByInvitationCode(

--- a/src/application/port/out/region/region.repository.ts
+++ b/src/application/port/out/region/region.repository.ts
@@ -1,4 +1,7 @@
 import { RepositoryPort } from '@application/port/out/repository.port';
 import { Region } from '@domain/region/region';
+import { RegionProps } from '@application/port/out/region/region.types';
 
-export type RegionRepository = RepositoryPort<Region>;
+export interface RegionRepository extends RepositoryPort<Region> {
+  find(props: RegionProps): Promise<Region>;
+}

--- a/src/application/port/out/region/region.repository.ts
+++ b/src/application/port/out/region/region.repository.ts
@@ -1,0 +1,4 @@
+import { RepositoryPort } from '@application/port/out/repository.port';
+import { Region } from '@domain/region/region';
+
+export type RegionRepository = RepositoryPort<Region>;

--- a/src/application/port/out/region/region.types.ts
+++ b/src/application/port/out/region/region.types.ts
@@ -1,0 +1,6 @@
+// All properties that a Region has
+export interface RegionProps {
+  city: string;
+  district: string;
+  neighborhood: string;
+}

--- a/src/application/port/out/user/user.repository.ts
+++ b/src/application/port/out/user/user.repository.ts
@@ -1,7 +1,8 @@
 import { User } from '@domain/user/user';
 import { SignUpDetails } from '@application/port/in/auth/command/auth.command';
+import { RepositoryPort } from '@application/port/out/repository.port';
 
-export interface UserRepository {
+export interface UserRepository extends RepositoryPort<User> {
   getById(userId: string): Promise<User | null>;
 
   getUserByPhoneNumber(phoneNumber: string): Promise<User | null>;

--- a/src/application/service/auth/sign-up.service.ts
+++ b/src/application/service/auth/sign-up.service.ts
@@ -14,6 +14,7 @@ import { InvitationRepository } from '@application/port/out/auth/invitation/invi
 import { NotFoundException } from '@common/exception/not-found.exception';
 import { Invitation, InvitationStatus } from '@domain/auth/invitation';
 import { Auth } from '@domain/auth/auth';
+import { Transactional } from '@common/decorator/transactional.decorator';
 
 export class SignUpService<T> implements SignUpUsecase {
   constructor(
@@ -24,6 +25,7 @@ export class SignUpService<T> implements SignUpUsecase {
     private readonly signInUsecase: SignInUsecase,
   ) {}
 
+  @Transactional()
   async exec(
     signUpCommand: SignUpCommand,
   ): Promise<AuthVerificationResponseCommand<User>> {
@@ -35,7 +37,6 @@ export class SignUpService<T> implements SignUpUsecase {
 
     invitation.setInvitationStatus(InvitationStatus.ACCEPTED);
 
-    // TODO: 트랜잭션 도입
     await this.userRepository.userSignUp(signUpCommand);
     await this.invitationRepository.updateInvitationStatus(
       invitation.id,

--- a/src/application/service/region/create-region.service.ts
+++ b/src/application/service/region/create-region.service.ts
@@ -2,11 +2,18 @@ import { CreateRegionUsecase } from '@application/port/in/region/create-region.u
 import { RegionRepository } from '@application/port/out/region/region.repository';
 import { CreateRegionCommand } from '@application/port/in/region/region.command';
 import { Region } from '@domain/region/region';
+import { AlreadyExistsException } from '@common/exception/already-exists.exception';
+import { Transactional } from '@common/decorator/transactional.decorator';
 
 export class CreateRegionService implements CreateRegionUsecase {
   constructor(private readonly regionRepository: RegionRepository) {}
 
-  async exec(createRegionCommand: CreateRegionCommand): Promise<void> {
+  @Transactional()
+  async exec(createRegionCommand: CreateRegionCommand): Promise<Region> {
+    const region = await this.regionRepository.find(createRegionCommand);
+    if (region)
+      throw new AlreadyExistsException('해당 지역이 이미 존재합니다.');
+
     await this.regionRepository.insert(
       Region.newInstanceWithDetails(
         createRegionCommand.city,
@@ -14,5 +21,10 @@ export class CreateRegionService implements CreateRegionUsecase {
         createRegionCommand.neighborhood,
       ),
     );
+
+    const newRegion = await this.regionRepository.find(createRegionCommand);
+    newRegion.checkLoaded();
+
+    return newRegion;
   }
 }

--- a/src/application/service/region/create-region.service.ts
+++ b/src/application/service/region/create-region.service.ts
@@ -7,10 +7,12 @@ export class CreateRegionService implements CreateRegionUsecase {
   constructor(private readonly regionRepository: RegionRepository) {}
 
   async exec(createRegionCommand: CreateRegionCommand): Promise<void> {
-    const { city, district, neighborhood } = createRegionCommand;
-
-    await this.regionRepository.save(
-      Region.newInstance(city.trim(), district.trim(), neighborhood.trim()),
+    await this.regionRepository.insert(
+      Region.newInstanceWithDetails(
+        createRegionCommand.city,
+        createRegionCommand.district,
+        createRegionCommand.neighborhood,
+      ),
     );
   }
 }

--- a/src/application/service/region/create-region.service.ts
+++ b/src/application/service/region/create-region.service.ts
@@ -1,0 +1,16 @@
+import { CreateRegionUsecase } from '@application/port/in/region/create-region.usecase';
+import { RegionRepository } from '@application/port/out/region/region.repository';
+import { CreateRegionCommand } from '@application/port/in/region/region.command';
+import { Region } from '@domain/region/region';
+
+export class CreateRegionService implements CreateRegionUsecase {
+  constructor(private readonly regionRepository: RegionRepository) {}
+
+  async exec(createRegionCommand: CreateRegionCommand): Promise<void> {
+    const { city, district, neighborhood } = createRegionCommand;
+
+    await this.regionRepository.save(
+      Region.newInstance(city.trim(), district.trim(), neighborhood.trim()),
+    );
+  }
+}

--- a/src/application/service/region/get-region-exact-location.service.ts
+++ b/src/application/service/region/get-region-exact-location.service.ts
@@ -1,0 +1,16 @@
+import { RegionRepository } from '@application/port/out/region/region.repository';
+import { GetRegionExactLocationCommand } from '@application/port/in/region/region.command';
+import { Region } from '@domain/region/region';
+import { GetRegionExactLocationQuery } from '@application/port/in/region/get-region-exact-location.query';
+
+export class GetRegionExactLocationService
+  implements GetRegionExactLocationQuery
+{
+  constructor(private readonly regionRepository: RegionRepository) {}
+
+  async exec(
+    getRegionExactLocationCommand: GetRegionExactLocationCommand,
+  ): Promise<Region> {
+    return await this.regionRepository.find(getRegionExactLocationCommand);
+  }
+}

--- a/src/application/service/region/get-region-exact-location.service.ts
+++ b/src/application/service/region/get-region-exact-location.service.ts
@@ -2,6 +2,7 @@ import { RegionRepository } from '@application/port/out/region/region.repository
 import { GetRegionExactLocationCommand } from '@application/port/in/region/region.command';
 import { Region } from '@domain/region/region';
 import { GetRegionExactLocationQuery } from '@application/port/in/region/get-region-exact-location.query';
+import { NotFoundException } from '@common/exception/not-found.exception';
 
 export class GetRegionExactLocationService
   implements GetRegionExactLocationQuery
@@ -11,6 +12,11 @@ export class GetRegionExactLocationService
   async exec(
     getRegionExactLocationCommand: GetRegionExactLocationCommand,
   ): Promise<Region> {
-    return await this.regionRepository.find(getRegionExactLocationCommand);
+    const region = await this.regionRepository.find(
+      getRegionExactLocationCommand,
+    );
+    if (!region)
+      throw new NotFoundException('해당하는 지역이 존재하지 않습니다.');
+    return region;
   }
 }

--- a/src/application/service/user/update-user-info.service.ts
+++ b/src/application/service/user/update-user-info.service.ts
@@ -21,7 +21,7 @@ export class UpdateUserInfoService implements UpdateUserInfoUsecase {
     if (!userInfo) userInfo = new UserInfo();
 
     if (command.nickname) user.setNickname(command.nickname);
-    if (command.region) userInfo.setRegion(command.region);
+    if (command.regionId) userInfo.setRegionId(command.regionId);
     if (command.gender) userInfo.setGender(command.gender);
     if (command.birth) userInfo.setBirth(command.birth);
 

--- a/src/application/service/user/update-user-info.service.ts
+++ b/src/application/service/user/update-user-info.service.ts
@@ -34,5 +34,11 @@ export class UpdateUserInfoService implements UpdateUserInfoUsecase {
       throw new NotFoundException('해당하는 사용자가 존재하지 않습니다.');
 
     return user;
+  private async getRegion(regionProps: Region): Promise<Region> {
+    return await this.regionRepository.find({
+      city: regionProps.getCity(),
+      district: regionProps.getDistrict(),
+      neighborhood: regionProps.getNeighborhood(),
+    });
   }
 }

--- a/src/application/service/user/update-user-info.service.ts
+++ b/src/application/service/user/update-user-info.service.ts
@@ -4,10 +4,19 @@ import { User } from '@domain/user/user';
 import { UserRepository } from '@application/port/out/user/user.repository';
 import { NotFoundException } from '@common/exception/not-found.exception';
 import { UserInfo } from '@domain/user/user-info';
+import { Region } from '@domain/region/region';
+import { RegionRepository } from '@application/port/out/region/region.repository';
+import { Transactional } from '@common/decorator/transactional.decorator';
+import { CreateRegionUsecase } from '@application/port/in/region/create-region.usecase';
 
 export class UpdateUserInfoService implements UpdateUserInfoUsecase {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly regionRepository: RegionRepository,
+    private readonly createRegionUsecase: CreateRegionUsecase,
+  ) {}
 
+  @Transactional()
   async exec(updateUserInfoCommand: UpdateUserInfoCommand): Promise<User> {
     const user = await this.ensureUserExists(updateUserInfoCommand.userId);
     await this.updateUserInfo(user, updateUserInfoCommand);
@@ -16,24 +25,46 @@ export class UpdateUserInfoService implements UpdateUserInfoUsecase {
     return user;
   }
 
-  private updateUserInfo(user: User, command: UpdateUserInfoCommand): void {
-    let userInfo = user.getUserInfo();
-    if (!userInfo) userInfo = new UserInfo();
-
-    if (command.nickname) user.setNickname(command.nickname);
-    if (command.regionId) userInfo.setRegionId(command.regionId);
-    if (command.gender) userInfo.setGender(command.gender);
-    if (command.birth) userInfo.setBirth(command.birth);
-
-    user.setUserInfo(userInfo);
-  }
-
   private async ensureUserExists(userId: string): Promise<User> {
     const user = await this.userRepository.getById(userId);
     if (!user)
       throw new NotFoundException('해당하는 사용자가 존재하지 않습니다.');
 
     return user;
+  }
+
+  private async updateUserInfo(
+    user: User,
+    command: UpdateUserInfoCommand,
+  ): Promise<void> {
+    let userInfo = user.getUserInfo();
+    if (!userInfo) userInfo = new UserInfo();
+
+    if (command.nickname) user.setNickname(command.nickname);
+    if (command.region)
+      userInfo.setRegion(
+        await this.findOrCreateRegion(Region.fromObject(command.region)),
+      );
+    if (command.gender) userInfo.setGender(command.gender);
+    if (command.birth) userInfo.setBirth(command.birth);
+
+    user.setUserInfo(userInfo);
+  }
+
+  private async findOrCreateRegion(regionProps: Region): Promise<Region> {
+    let region = await this.getRegion(regionProps);
+
+    if (!region || !region.checkLoaded()) {
+      region = await this.createRegionUsecase.exec({
+        city: regionProps.getCity(),
+        district: regionProps.getDistrict(),
+        neighborhood: regionProps.getNeighborhood(),
+      });
+    }
+
+    return region;
+  }
+
   private async getRegion(regionProps: Region): Promise<Region> {
     return await this.regionRepository.find({
       city: regionProps.getCity(),

--- a/src/common/decorator/transactional.decorator.ts
+++ b/src/common/decorator/transactional.decorator.ts
@@ -15,7 +15,7 @@ export function Transactional() {
       const connection = transactionManager.getConnection();
 
       if (transactionSessionStorage.getTransaction()) {
-        await originalMethod.apply(this, args);
+        return await originalMethod.apply(this, args);
       }
 
       const session = await connection.startSession();
@@ -23,8 +23,9 @@ export function Transactional() {
 
       try {
         session.startTransaction();
-        await originalMethod.apply(this, args);
+        const result = await originalMethod.apply(this, args);
         await session.commitTransaction();
+        return result;
       } catch (err) {
         await session.abortTransaction();
         throw err;

--- a/src/common/exception/already-exists.exception.ts
+++ b/src/common/exception/already-exists.exception.ts
@@ -1,0 +1,7 @@
+import { BaseException } from '@common/exception/base.exception';
+
+export class AlreadyExistsException extends BaseException {
+  constructor(message = 'Already Exists Exception', status = 409) {
+    super(message, status);
+  }
+}

--- a/src/domain/auth/exception/invalid-invitation-status.exception.ts
+++ b/src/domain/auth/exception/invalid-invitation-status.exception.ts
@@ -1,0 +1,7 @@
+import { BaseException } from '@common/exception/base.exception';
+
+export class InvalidInvitationStatusException extends BaseException {
+  constructor(message = '해당 초대 코드를 사용할 수 없습니다.', status = 410) {
+    super(message, status);
+  }
+}

--- a/src/domain/auth/invitation.ts
+++ b/src/domain/auth/invitation.ts
@@ -1,4 +1,5 @@
 import { Domain } from '@domain/domain';
+import { InvalidInvitationStatusException } from '@domain/auth/exception/invalid-invitation-status.exception';
 
 export enum InvitationType {
   ADMIN = 'ADMIN',
@@ -41,5 +42,10 @@ export class Invitation extends Domain {
 
   getInvitationStatus(): InvitationStatus {
     return this.invitationStatus;
+  }
+
+  checkInvitationStatus(): void {
+    if (this.invitationStatus !== InvitationStatus.PENDING)
+      throw new InvalidInvitationStatusException();
   }
 }

--- a/src/domain/region/exception/region-not-loaded.exception.ts
+++ b/src/domain/region/exception/region-not-loaded.exception.ts
@@ -1,0 +1,7 @@
+import { BaseException } from '@common/exception/base.exception';
+
+export class RegionNotLoadedException extends BaseException {
+  constructor(message = 'Region Not Loaded Exception', status = 500) {
+    super(message, status);
+  }
+}

--- a/src/domain/region/region.ts
+++ b/src/domain/region/region.ts
@@ -1,18 +1,27 @@
+import { Domain } from '@domain/domain';
+
 /**
  * 대한민국의 특정 지역을 나타내는 클래스입니다.
  * docs: https://business.juso.go.kr/addrlink/attrbDBDwld/attrbDBDwldList.do?cPath=99MD
  */
-export class Region {
+export class Region extends Domain {
   /**
    *  @param {string} id - 지역의 고유 ID입니다.
    *  @param {string} city - 지역의 '시도'를 나타냅니다.
    *  @param {string} district - 지역의 '시군구'를 나타냅니다.
    *  @param {string} neighborhood - 지역의 '법정 읍면동'을 나타냅니다.
    */
+
   constructor(
     public readonly id: string,
     public readonly city: string,
     public readonly district: string,
     public readonly neighborhood: string,
-  ) {}
+  ) {
+    super();
+  }
+
+  static newInstance(city: string, district: string, neighborhood: string) {
+    return new Region(null, city, district, neighborhood);
+  }
 }

--- a/src/domain/region/region.ts
+++ b/src/domain/region/region.ts
@@ -1,4 +1,5 @@
 import { Domain } from '@domain/domain';
+import { RegionNotLoadedException } from '@domain/region/exception/region-not-loaded.exception';
 
 /**
  * 대한민국의 특정 지역을 나타내는 클래스입니다.
@@ -40,6 +41,12 @@ export class Region extends Domain {
   getNeighborhood(): string {
     return this.neighborhood;
   }
+
+  checkLoaded(): boolean {
+    if (!this.loaded) throw new RegionNotLoadedException();
+    return this.loaded;
+  }
+
   static newInstance(id: string) {
     return new Region(id);
   }

--- a/src/domain/region/region.ts
+++ b/src/domain/region/region.ts
@@ -20,8 +20,23 @@ export class Region extends Domain {
   ) {
     super();
   }
+  static newInstance(id: string) {
+    return new Region(id);
+  }
 
-  static newInstance(city: string, district: string, neighborhood: string) {
+  static newInstanceWithDetails(
+    city: string,
+    district: string,
+    neighborhood: string,
+  ) {
     return new Region(null, city, district, neighborhood);
+  }
+
+  static fromObject(obj: any): Region {
+    return this.newInstanceWithDetails(
+      obj.city,
+      obj.district,
+      obj.neighborhood,
+    );
   }
 }

--- a/src/domain/region/region.ts
+++ b/src/domain/region/region.ts
@@ -12,13 +12,33 @@ export class Region extends Domain {
    *  @param {string} neighborhood - 지역의 '법정 읍면동'을 나타냅니다.
    */
 
+  private readonly loaded: boolean = false;
+
   constructor(
-    public readonly id: string,
-    public readonly city: string,
-    public readonly district: string,
-    public readonly neighborhood: string,
+    readonly id: string,
+    private readonly city?: string,
+    private readonly district?: string,
+    private readonly neighborhood?: string,
   ) {
     super();
+
+    if (city) city.trim();
+    if (district) district.trim();
+    if (neighborhood) neighborhood.trim();
+
+    if (city && district && neighborhood) this.loaded = true;
+  }
+
+  getCity(): string {
+    return this.city;
+  }
+
+  getDistrict(): string {
+    return this.district;
+  }
+
+  getNeighborhood(): string {
+    return this.neighborhood;
   }
   static newInstance(id: string) {
     return new Region(id);

--- a/src/domain/user/user-info.ts
+++ b/src/domain/user/user-info.ts
@@ -52,6 +52,7 @@ export class UserInfo {
   }
 
   static fromObject(obj: any): UserInfo {
+    if (!obj) return new UserInfo();
     return new UserInfo(obj.gender, obj.birth, obj.region);
   }
 }

--- a/src/domain/user/user-info.ts
+++ b/src/domain/user/user-info.ts
@@ -1,4 +1,5 @@
 import { InvalidBirthFormatException } from '@domain/user/exception/invalid-birth-format.exception';
+import { Region } from '@domain/region/region';
 
 export enum Gender {
   MALE = 'MALE',
@@ -9,16 +10,16 @@ export enum Gender {
 export class UserInfo {
   private gender?: Gender;
   private birth?: string;
-  private regionId?: string;
+  private region?: Region;
 
   constructor(
     gender: Gender = null,
     birth: string = null,
-    regionId: string = null,
+    region: Region = null,
   ) {
     this.setGender(gender);
     this.setBirth(birth);
-    this.regionId = regionId;
+    this.setRegion(region);
   }
 
   setGender(gender: Gender) {
@@ -43,12 +44,12 @@ export class UserInfo {
     return this.birth;
   }
 
-  setRegionId(regionId: string) {
-    this.regionId = regionId;
+  setRegion(region: Region) {
+    this.region = region;
   }
 
-  getRegionId(): string {
-    return this.regionId;
+  getRegion(): Region {
+    return this.region;
   }
 
   static fromObject(obj: any): UserInfo {

--- a/src/domain/user/user-info.ts
+++ b/src/domain/user/user-info.ts
@@ -1,4 +1,3 @@
-import { Region } from '@domain/region/region';
 import { InvalidBirthFormatException } from '@domain/user/exception/invalid-birth-format.exception';
 
 export enum Gender {
@@ -10,16 +9,16 @@ export enum Gender {
 export class UserInfo {
   private gender?: Gender;
   private birth?: string;
-  private region?: Region;
+  private regionId?: string;
 
   constructor(
     gender: Gender = null,
     birth: string = null,
-    region: Region = null,
+    regionId: string = null,
   ) {
     this.setGender(gender);
     this.setBirth(birth);
-    this.setRegion(region);
+    this.regionId = regionId;
   }
 
   setGender(gender: Gender) {
@@ -44,12 +43,12 @@ export class UserInfo {
     return this.birth;
   }
 
-  setRegion(region: Region) {
-    this.region = region;
+  setRegionId(regionId: string) {
+    this.regionId = regionId;
   }
 
-  getRegion(): Region {
-    return this.region;
+  getRegionId(): string {
+    return this.regionId;
   }
 
   static fromObject(obj: any): UserInfo {

--- a/src/domain/user/user.ts
+++ b/src/domain/user/user.ts
@@ -24,8 +24,8 @@ export class User extends Domain implements Accountable {
     nickname: string,
     userInfo: UserInfo,
     phoneNumber: string,
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: Date = new Date(),
+    updatedAt: Date = new Date(),
     authToken: AuthToken = null,
   ) {
     super();
@@ -97,5 +97,13 @@ export class User extends Domain implements Accountable {
 
   getDeletedAt(): Date {
     return this.deletedAt;
+  }
+
+  public static newInstance(
+    nickname: string,
+    userInfo: UserInfo,
+    phoneNumber: string,
+  ): User {
+    return new User(null, nickname, userInfo, phoneNumber);
   }
 }


### PR DESCRIPTION
## OverView
1. Region 도메인 디자인
   - `Region` 도메인과 관련된 Repository 및 Usecase 와 관련된 코드를 구현하였습니다.
   - `UserInfo` 도메인의 `RegionId` 필드를 `Embedding Document` 형식으로 수정하여, `Region` 필드를 참조하도록 수정하였습니다.
2. Create Region Service 구현
   - `Region` 도메인 생성을 위한 서비스를 구현하였습니다.
   - 해당 Service는 "사용자가 주소를 입력할 때, 해당 주소를 DB에 생성"하도록 설계되었습니다.
   - 추후 해당 `Region`은 게시판 기능과 연결될 예정입니다.
3. Transactional Decorator 개선
   - Transactional Decorator에서 Return Value가 존재하지 않았던 문제를 수정하였습니다.
4. Repository 인터페이스 개선
   - 모든 도메인의 Repository 인터페이스가 `RepositoryPort`를 상속받도록 수정하였습니다.
   - 그로인해, Application 계층에서도 `Repository` 구현체의 `insert`, `findById`와 같은 메서드를 사용할 수 있도록 수정하였습니다.
5. Repository 구현체 개선
   - Infrastructure 계층의 모든 `Repository` 구현체가 이제 mongoose session을 사용하도록 수정되었습니다.
   - 그로인해, 기존에 작성된 모든 비즈니스 로직에서도 Transactional Decorator를 도입할 수 있게 되었습니다.

## Next
1. 유닛 테스트 코드 도입
   - 핵심 비즈니스 로직에 많은 변경이 있었기 때문에, Domain 및 Service에 대한 유닛 테스트 코드가 도입되어야 합니다.

